### PR TITLE
[HC-93] Spring Security 활용 유저 로그인 정보 추출

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,9 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v1
         with:
-          java-version: 17
+          java-version: '17'
+      - run: touch ./src/main/resources/application.properties
+      - run: echo "${{ secrets.APPLICATION_PROPERTIES }}" > ./src/main/resources/application.properties
  
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/README.md
+++ b/README.md
@@ -1,0 +1,52 @@
+# 답변, 받았습니다! (Backend)
+
+<p align="center">
+  <img src="https://github.com/Honeycourse/honeycourses-frontend/blob/main/2a08b3abb803c6f2c999fcc7e7d0cfb.png" alt="logo"/>
+</p>
+
+답변, 받았습니다! 는 북경대학교 한국인 유학생들을 위한 강의 정보공유 웹사이트입니다.
+
+본 repo는 답변, 받았습니다!의 Spring Boot 백엔드 코드를 관리하고 있습니다.
+
+<br>
+
+## :pushpin: Features
+
+- **수업 리뷰 찾기/등록**
+- **익명 기반 커뮤니티**
+
+<br>
+
+## :people_hugging: Authors
+
+<table>
+  <tr height="150px">
+  <td align="center">
+    <a href="https://github.com/timingsniper"><img height="150px" width="150px" src="https://avatars.githubusercontent.com/u/17792896?v=4"/></a>
+    <br />
+    <a href="https://github.com/timingsniper">장준우 </a>
+  </td>
+  <td align="center">
+    <a href="https://github.com/pagh2322"><img height="150px" width="150px" src="https://avatars.githubusercontent.com/u/73037262?v=4"/></a>
+    <br />
+    <a href="https://github.com/pagh2322">박건호 </a>
+  </td>
+  </tr>
+</table>
+
+<br>
+
+## :sparkles: Skills & Tech Stack
+
+### Backend
+
+- Spring Boot (Java)
+- MySQL
+- AWS EC2
+- Docker
+
+<br>
+
+## Requirements
+
+- JDK 17

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,9 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'mysql:mysql-connector-java'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     runtimeOnly 'com.h2database:h2'
 

--- a/src/main/java/org/wooriverygood/api/config/SecurityConfig.java
+++ b/src/main/java/org/wooriverygood/api/config/SecurityConfig.java
@@ -1,0 +1,43 @@
+package org.wooriverygood.api.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.wooriverygood.api.support.TokenProvider;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final TokenProvider tokenProvider;
+
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http.csrf(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
+                        authorizationManagerRequestMatcherRegistry
+                                .requestMatchers("/community").permitAll() // 권한이 필요없는 엔드 포인트, 임시로 게시글만 허용
+                                .anyRequest().authenticated())
+                .oauth2ResourceServer(httpSecurityOAuth2ResourceServerConfigurer ->
+                        httpSecurityOAuth2ResourceServerConfigurer.jwt(jwtConfigurer ->
+                                jwtConfigurer.decoder(tokenProvider.accessTokenDecoder())))
+                .httpBasic(Customizer.withDefaults())
+                .build();
+    }
+}

--- a/src/main/java/org/wooriverygood/api/config/WebConfig.java
+++ b/src/main/java/org/wooriverygood/api/config/WebConfig.java
@@ -1,0 +1,34 @@
+package org.wooriverygood.api.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.wooriverygood.api.support.AuthenticationPrincipalArgumentResolver;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Bean
+    public AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver() {
+        return new AuthenticationPrincipalArgumentResolver();
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticationPrincipalArgumentResolver());
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOriginPatterns("*")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .exposedHeaders("*");
+    }
+}

--- a/src/main/java/org/wooriverygood/api/support/AuthInfo.java
+++ b/src/main/java/org/wooriverygood/api/support/AuthInfo.java
@@ -1,0 +1,17 @@
+package org.wooriverygood.api.support;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AuthInfo {
+
+    private final String sub;
+    private final String username;
+
+    @Builder
+    public AuthInfo(String sub, String username) {
+        this.sub = sub;
+        this.username = username;
+    }
+}

--- a/src/main/java/org/wooriverygood/api/support/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/org/wooriverygood/api/support/AuthenticationPrincipalArgumentResolver.java
@@ -1,0 +1,41 @@
+package org.wooriverygood.api.support;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Login.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        // SecurityContextHolder를 통해 현재 인증된 사용자의 Authentication을 가져옴
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        // Authentication 객체에서 Jwt를 추출
+        if (authentication != null && authentication.getPrincipal() instanceof Jwt jwt) {
+            return createAuthInfo(jwt);
+        } else {
+            throw new RuntimeException("Jwt not found in the authentication context");
+        }
+    }
+
+    private AuthInfo createAuthInfo(Jwt jwt) {
+        String sub = jwt.getClaim("sub");
+        String username = jwt.getClaim("username");
+
+        return AuthInfo.builder()
+                .sub(sub)
+                .username(username)
+                .build();
+    }
+}

--- a/src/main/java/org/wooriverygood/api/support/Login.java
+++ b/src/main/java/org/wooriverygood/api/support/Login.java
@@ -1,0 +1,11 @@
+package org.wooriverygood.api.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Login {
+}

--- a/src/main/java/org/wooriverygood/api/support/TokenProvider.java
+++ b/src/main/java/org/wooriverygood/api/support/TokenProvider.java
@@ -1,0 +1,17 @@
+package org.wooriverygood.api.support;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenProvider {
+
+    @Value("${aws.cognito.uri}")
+    private String uri;
+
+    public JwtDecoder accessTokenDecoder() {
+        return NimbusJwtDecoder.withJwkSetUri(uri).build();
+    }
+}


### PR DESCRIPTION
 Spring Security 를 활용해서 요청 헤더에 토큰으로 요청마다 인증 처리를 진행합니다.

 유효한 access token 이라면, AuthenticationPrincipalArgumentResolver 에서 인증된 유저의 Authentication 을 가져와 필요한 유저 로그인 정보(AuthInfo)로 변환합니다.

 컨트롤러는 메서드의 패러미터로 `@Login AuthInfo authInfo` 로 정보를 받을 수 있습니다.

 예시:

 ```java
 @GetMapping
 public void testMethod(@Login AuthInfo authInfo) {
     String sub = authInfo.sub;
     String username = authInfo.username
 }
 ```

 sub와 username은 모두 같은 값을 가지고 있지만, 일단 둘 다 값을 가지도록 하였습니다.

TokenProvider의 uri 값은 보안 상 properties에 설정했습니다.