### PR TITLE
[HC-69] 게시글 생성 엔드 포인트 RequestBody 수정

### DIFF
--- a/src/main/java/org/wooriverygood/api/post/controller/PostController.java
+++ b/src/main/java/org/wooriverygood/api/post/controller/PostController.java
@@ -7,6 +7,8 @@ import org.wooriverygood.api.post.dto.NewPostRequest;
 import org.wooriverygood.api.post.dto.NewPostResponse;
 import org.wooriverygood.api.post.dto.PostResponse;
 import org.wooriverygood.api.post.service.PostService;
+import org.wooriverygood.api.support.AuthInfo;
+import org.wooriverygood.api.support.Login;
 
 import java.util.List;
 
@@ -34,8 +36,9 @@ public class PostController {
     }
 
     @PostMapping
-    public ResponseEntity<NewPostResponse> addPost(@RequestBody NewPostRequest newPostRequest) {
-        NewPostResponse response = postService.addPost(newPostRequest);
+    public ResponseEntity<NewPostResponse> addPost(@Login AuthInfo authInfo,
+                                                   @RequestBody NewPostRequest newPostRequest) {
+        NewPostResponse response = postService.addPost(authInfo, newPostRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 }

--- a/src/main/java/org/wooriverygood/api/post/dto/NewPostRequest.java
+++ b/src/main/java/org/wooriverygood/api/post/dto/NewPostRequest.java
@@ -9,13 +9,11 @@ public class NewPostRequest {
     private final String post_title;
     private final String post_category;
     private final String post_content;
-    private final String email;
 
     @Builder
-    public NewPostRequest(String post_title, String post_category, String post_content, String email) {
+    public NewPostRequest(String post_title, String post_category, String post_content) {
         this.post_title = post_title;
         this.post_category = post_category;
         this.post_content = post_content;
-        this.email = email;
     }
 }

--- a/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java
@@ -8,12 +8,14 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.wooriverygood.api.exception.PostNotFoundException;
 import org.wooriverygood.api.post.domain.Post;
 import org.wooriverygood.api.post.domain.PostCategory;
 import org.wooriverygood.api.post.dto.NewPostRequest;
 import org.wooriverygood.api.post.dto.NewPostResponse;
 import org.wooriverygood.api.post.dto.PostResponse;
 import org.wooriverygood.api.post.repository.PostRepository;
+import org.wooriverygood.api.support.AuthInfo;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +35,7 @@ class PostServiceTest {
     private final int POST_COUNT = 10;
 
     List<Post> posts = new ArrayList<>();
+
     Post singlePost = Post.builder()
             .id(6L)
             .category(PostCategory.OFFER)
@@ -42,6 +45,12 @@ class PostServiceTest {
             .comments(new ArrayList<>())
             .postLikes(new ArrayList<>())
             .build();
+
+    AuthInfo authInfo = AuthInfo.builder()
+            .sub("22222-34534-123")
+            .username("22222-34534-123")
+            .build();
+
 
     @BeforeEach
     void setUpPosts() {
@@ -58,7 +67,6 @@ class PostServiceTest {
             posts.add(post);
         }
     }
-
 
     @Test
     @DisplayName("모든 게시글을 불러온다.")
@@ -83,13 +91,22 @@ class PostServiceTest {
     }
 
     @Test
+    @DisplayName("유효하지 않은 id를 이용하여 특정 게시글을 불러온다.")
+    void findPostByIdAndThrowException() {
+        Mockito.when(postRepository.findById(any()))
+                .thenThrow(PostNotFoundException.class);
+
+        Assertions.assertThatThrownBy(() -> { postService.findPostById(6L); })
+                .isInstanceOf(PostNotFoundException.class);
+    }
+
+    @Test
     @DisplayName("새로운 게시글을 작성한다.")
     void addPost() {
         NewPostRequest newPostRequest = NewPostRequest.builder()
                 .post_title("title")
                 .post_category("자유")
                 .post_content("content")
-                .email("test@email.com")
                 .build();
 
         Mockito.when(postRepository.save(any(Post.class)))
@@ -97,14 +114,14 @@ class PostServiceTest {
                         .title(newPostRequest.getPost_title())
                         .category(PostCategory.parse(newPostRequest.getPost_category()))
                         .content(newPostRequest.getPost_content())
-                        .author(newPostRequest.getEmail())
+                        .author(authInfo.getUsername())
                         .build());
 
-        NewPostResponse response = postService.addPost(newPostRequest);
+        NewPostResponse response = postService.addPost(authInfo, newPostRequest);
 
         Assertions.assertThat(response.getTitle()).isEqualTo(newPostRequest.getPost_title());
         Assertions.assertThat(response.getCategory()).isEqualTo(newPostRequest.getPost_category());
-        Assertions.assertThat(response.getAuthor()).isEqualTo(newPostRequest.getEmail());
+        Assertions.assertThat(response.getAuthor()).isEqualTo(authInfo.getUsername());
     }
 
 }


### PR DESCRIPTION
기존 RequestBody에서는 post_author로 유저의 정보를 가져왔지만, 이제 AuthInfo로 가져온 유저의 메일로 게시글의 작성자를 설정합니다.

PostService 테스트 코드도 수정했습니다.