### PR TITLE
[HC-85] 내 정보 글 조회 기능 구현

### DIFF
--- a/src/main/java/org/wooriverygood/api/post/controller/PostController.java
+++ b/src/main/java/org/wooriverygood/api/post/controller/PostController.java
@@ -25,14 +25,15 @@ public class PostController {
     }
 
     @GetMapping
-    public ResponseEntity<List<PostResponse>> findAllPosts() {
-        List<PostResponse> postResponses = postService.findAllPosts();
+    public ResponseEntity<List<PostResponse>> findAllPosts(@Login AuthInfo authInfo) {
+        List<PostResponse> postResponses = postService.findAllPosts(authInfo);
         return ResponseEntity.ok().body(postResponses);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<PostResponse> findPostById(@PathVariable("id") Long postId) {
-        PostResponse postResponse = postService.findPostById(postId);
+    public ResponseEntity<PostResponse> findPostById(@PathVariable("id") Long postId,
+                                                     @Login AuthInfo authInfo) {
+        PostResponse postResponse = postService.findPostById(postId, authInfo);
         return ResponseEntity.ok().body(postResponse);
     }
 
@@ -41,5 +42,11 @@ public class PostController {
                                                    @Valid @RequestBody NewPostRequest newPostRequest) {
         NewPostResponse response = postService.addPost(authInfo, newPostRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<List<PostResponse>> findMyPosts(@Login AuthInfo authInfo) {
+        List<PostResponse> postResponses = postService.findMyPosts(authInfo);
+        return ResponseEntity.ok().body(postResponses);
     }
 }

--- a/src/main/java/org/wooriverygood/api/post/domain/Post.java
+++ b/src/main/java/org/wooriverygood/api/post/domain/Post.java
@@ -58,4 +58,8 @@ public class Post {
         this.postLikes = postLikes;
     }
 
+    public boolean isSameAuthor(String author) {
+        return this.author.equals(author);
+    }
+
 }

--- a/src/main/java/org/wooriverygood/api/post/dto/PostResponse.java
+++ b/src/main/java/org/wooriverygood/api/post/dto/PostResponse.java
@@ -16,9 +16,10 @@ public class PostResponse {
     private final int post_comments;
     private final int post_likes;
     private final LocalDateTime post_time;
+    private final boolean isMine;
 
     @Builder
-    public PostResponse(Long post_id, String post_title, String post_content, String post_category, int post_comments, int post_likes, LocalDateTime post_time) {
+    public PostResponse(Long post_id, String post_title, String post_content, String post_category, int post_comments, int post_likes, LocalDateTime post_time, boolean isMine) {
         this.post_id = post_id;
         this.post_title = post_title;
         this.post_content = post_content;
@@ -26,9 +27,10 @@ public class PostResponse {
         this.post_comments = post_comments;
         this.post_likes = post_likes;
         this.post_time = post_time;
+        this.isMine = isMine;
     }
 
-    public static PostResponse from(Post post) {
+    public static PostResponse from(Post post, boolean isMine) {
         return PostResponse.builder()
                 .post_id(post.getId())
                 .post_title(post.getTitle())
@@ -37,6 +39,7 @@ public class PostResponse {
                 .post_comments(post.getComments().size())
                 .post_likes(post.getPostLikes().size())
                 .post_time(post.getCreatedAt())
+                .isMine(isMine)
                 .build();
     }
 

--- a/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java
+++ b/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java
@@ -3,5 +3,9 @@ package org.wooriverygood.api.post.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.wooriverygood.api.post.domain.Post;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    List<Post> findByAuthor(String author);
 }

--- a/src/main/java/org/wooriverygood/api/support/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/org/wooriverygood/api/support/AuthenticationPrincipalArgumentResolver.java
@@ -17,16 +17,11 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        // SecurityContextHolder를 통해 현재 인증된 사용자의 Authentication을 가져옴
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-        // Authentication 객체에서 Jwt를 추출
-        if (authentication != null && authentication.getPrincipal() instanceof Jwt jwt) {
-            return createAuthInfo(jwt);
-        } else {
-            throw new RuntimeException("Jwt not found in the authentication context");
-        }
+        if (authentication != null && authentication.getPrincipal() instanceof Jwt jwt) return createAuthInfo(jwt);
+        return AuthInfo.builder().build();
     }
 
     private AuthInfo createAuthInfo(Jwt jwt) {

--- a/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java
@@ -60,7 +60,7 @@ class PostServiceTest {
                     .category(PostCategory.FREE)
                     .title("title" + i)
                     .content("content" + i)
-                    .author("author" + i)
+                    .author(authInfo.getUsername())
                     .comments(new ArrayList<>())
                     .postLikes(new ArrayList<>())
                     .build();
@@ -74,7 +74,7 @@ class PostServiceTest {
         Mockito.when(postRepository.findAll())
                 .thenReturn(posts);
 
-        List<PostResponse> responses = postService.findAllPosts();
+        List<PostResponse> responses = postService.findAllPosts(authInfo);
 
         Assertions.assertThat(responses.size()).isEqualTo(POST_COUNT);
     }
@@ -85,7 +85,7 @@ class PostServiceTest {
         Mockito.when(postRepository.findById(any()))
                 .thenReturn(Optional.ofNullable(singlePost));
 
-        PostResponse response = postService.findPostById(6L);
+        PostResponse response = postService.findPostById(6L, authInfo);
 
         Assertions.assertThat(response).isNotNull();
     }
@@ -96,7 +96,7 @@ class PostServiceTest {
         Mockito.when(postRepository.findById(any()))
                 .thenThrow(PostNotFoundException.class);
 
-        Assertions.assertThatThrownBy(() -> { postService.findPostById(6L); })
+        Assertions.assertThatThrownBy(() -> postService.findPostById(6L, authInfo))
                 .isInstanceOf(PostNotFoundException.class);
     }
 
@@ -122,6 +122,17 @@ class PostServiceTest {
         Assertions.assertThat(response.getTitle()).isEqualTo(newPostRequest.getPost_title());
         Assertions.assertThat(response.getCategory()).isEqualTo(newPostRequest.getPost_category());
         Assertions.assertThat(response.getAuthor()).isEqualTo(authInfo.getUsername());
+    }
+
+    @Test
+    @DisplayName("사용자 본인이 작성한 게시글을 불러온다.")
+    void findMyPosts() {
+        Mockito.when(postRepository.findByAuthor(any(String.class)))
+                .thenReturn(posts);
+
+        List<PostResponse> responses = postService.findMyPosts(authInfo);
+
+        Assertions.assertThat(responses.get(0).isMine()).isEqualTo(true);
     }
 
 }


### PR DESCRIPTION
#### 사용자가 작성한 게시글 판별

PostResponse.isMine 추가 : 게시글 정보 반환 시, 해당 게시글이 본인이 작성한 지 판별하는 값.

#### 로그인 정보 없을 시

로그인 정보 없이 해당 api에 요청하면, AuthInfo의 2개의 필드 값 모두 null로 설정되며, 반환하는 PostResponse.isMine 값은 false로 자동 설정.