### PR TITLE
[HC-104] 게시글 카테고리 유효 검증 추가 및 에러 처리 로직 추가

### DIFF
--- a/src/main/java/org/wooriverygood/api/advice/CommentNotFoundExceptionHandler.java
+++ b/src/main/java/org/wooriverygood/api/advice/CommentNotFoundExceptionHandler.java
@@ -1,0 +1,15 @@
+package org.wooriverygood.api.advice;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.wooriverygood.api.exception.CommentNotFoundException;
+
+@ControllerAdvice
+public class CommentNotFoundExceptionHandler {
+
+    @ExceptionHandler(CommentNotFoundException.class)
+    public ResponseEntity<String> handle() {
+        return ResponseEntity.badRequest().body("댓글을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/org/wooriverygood/api/advice/InvalidPostCategoryExceptionHandler.java
+++ b/src/main/java/org/wooriverygood/api/advice/InvalidPostCategoryExceptionHandler.java
@@ -1,0 +1,15 @@
+package org.wooriverygood.api.advice;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.wooriverygood.api.exception.InvalidPostCategoryException;
+
+@ControllerAdvice
+public class InvalidPostCategoryExceptionHandler {
+
+    @ExceptionHandler(InvalidPostCategoryException.class)
+    public ResponseEntity<String> handle() {
+        return ResponseEntity.badRequest().body("게시글의 카테고리가 유효하지 않습니다.");
+    }
+}

--- a/src/main/java/org/wooriverygood/api/advice/PostNotFoundExceptionHandler.java
+++ b/src/main/java/org/wooriverygood/api/advice/PostNotFoundExceptionHandler.java
@@ -1,0 +1,15 @@
+package org.wooriverygood.api.advice;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.wooriverygood.api.exception.PostNotFoundException;
+
+@ControllerAdvice
+public class PostNotFoundExceptionHandler {
+
+    @ExceptionHandler(PostNotFoundException.class)
+    public ResponseEntity<String> handle() {
+        return ResponseEntity.badRequest().body("게시글을 찾을 수 없습니다.");
+    }
+}

--- a/src/main/java/org/wooriverygood/api/config/SecurityConfig.java
+++ b/src/main/java/org/wooriverygood/api/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
         return http.csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
                         authorizationManagerRequestMatcherRegistry
-                                .requestMatchers("/community").permitAll() // 권한이 필요없는 엔드 포인트, 임시로 게시글만 허용
+                                .requestMatchers("/**").permitAll() // 권한이 필요없는 엔드 포인트, 임시로 게시글만 허용
                                 .anyRequest().authenticated())
                 .oauth2ResourceServer(httpSecurityOAuth2ResourceServerConfigurer ->
                         httpSecurityOAuth2ResourceServerConfigurer.jwt(jwtConfigurer ->

--- a/src/main/java/org/wooriverygood/api/exception/InvalidPostCategoryException.java
+++ b/src/main/java/org/wooriverygood/api/exception/InvalidPostCategoryException.java
@@ -1,0 +1,12 @@
+package org.wooriverygood.api.exception;
+
+import org.wooriverygood.api.exception.general.BusinessException;
+
+public class InvalidPostCategoryException extends BusinessException {
+
+    private static final String MESSAGE = "유효한 카테고리가 아닙니다.";
+
+    public InvalidPostCategoryException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/org/wooriverygood/api/post/domain/PostCategory.java
+++ b/src/main/java/org/wooriverygood/api/post/domain/PostCategory.java
@@ -1,6 +1,7 @@
 package org.wooriverygood.api.post.domain;
 
 import lombok.Getter;
+import org.wooriverygood.api.exception.InvalidPostCategoryException;
 
 @Getter
 public enum PostCategory {
@@ -16,12 +17,13 @@ public enum PostCategory {
         return this.value.equals(value);
     }
 
-    public static PostCategory parse(String value) {
+    public static PostCategory parse(String value) throws InvalidPostCategoryException {
         return switch (value) {
             case "자유" -> PostCategory.FREE;
             case "질문" -> PostCategory.QUESTION;
             case "중고거래" -> PostCategory.TRADE;
-            default -> PostCategory.OFFER;
+            case "구인" -> PostCategory.OFFER;
+            default -> throw new InvalidPostCategoryException();
         };
     }
 }

--- a/src/main/java/org/wooriverygood/api/post/service/PostService.java
+++ b/src/main/java/org/wooriverygood/api/post/service/PostService.java
@@ -52,6 +52,7 @@ public class PostService {
 
     @Transactional
     public NewPostResponse addPost(AuthInfo authInfo, NewPostRequest newPostRequest) {
+        PostCategory.parse(newPostRequest.getPost_category());
         Post post = createPost(authInfo, newPostRequest);
         Post saved = postRepository.save(post);
         return createResponse(saved);

--- a/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.wooriverygood.api.exception.InvalidPostCategoryException;
 import org.wooriverygood.api.exception.PostNotFoundException;
 import org.wooriverygood.api.post.domain.Post;
 import org.wooriverygood.api.post.domain.PostCategory;
@@ -76,8 +77,8 @@ class PostServiceTest {
     }
 
     @Test
-    @DisplayName("모든 게시글을 불러온다.")
-    void findAllPosts() {
+    @DisplayName("로그인 한 상황에서 모든 게시글을 불러온다.")
+    void findAllPosts_login() {
         Mockito.when(postRepository.findAll())
                 .thenReturn(posts);
 
@@ -98,8 +99,8 @@ class PostServiceTest {
     }
 
     @Test
-    @DisplayName("유효하지 않은 id를 이용하여 특정 게시글을 불러온다.")
-    void findPostByIdAndThrowException() {
+    @DisplayName("유효하지 않은 id를 이용하여 특정 게시글을 불러오면 에러를 반환한다.")
+    void findPostById_exception_invalidId() {
         Mockito.when(postRepository.findById(any()))
                 .thenThrow(PostNotFoundException.class);
 
@@ -129,6 +130,19 @@ class PostServiceTest {
         Assertions.assertThat(response.getTitle()).isEqualTo(newPostRequest.getPost_title());
         Assertions.assertThat(response.getCategory()).isEqualTo(newPostRequest.getPost_category());
         Assertions.assertThat(response.getAuthor()).isEqualTo(authInfo.getUsername());
+    }
+
+    @Test
+    @DisplayName("새로운 게시글의 카테고리가 유효하지 않으면 등록에 실패한다.")
+    void addPost_exception_invalid_category() {
+        NewPostRequest newPostRequest = NewPostRequest.builder()
+                .post_title("title")
+                .post_category("자유유")
+                .post_content("content")
+                .build();
+
+        Assertions.assertThatThrownBy(() -> postService.addPost(authInfo, newPostRequest))
+                        .isInstanceOf(InvalidPostCategoryException.class);
     }
 
     @Test


### PR DESCRIPTION
### 유효성 검증

유효한 카테고리는 다음과 같아요.

자유, 질문, 중고거래, 구인

상위 4개를 제외한 다른 문자열이 카테고리에 값으로 요청이 오면, 게시글을 생성하지 않아요.

### 에러 처리

문제점: 게시글을 찾을 수 없거나, 작성한 게시글의 카테고리가 유효하지 않으면 런타임 에러를 발생하지만 프론트에서는 500번대 에러만 받아요. ControllerAdvice를 통해, 특정 에러가 발생하면 이를 처리하는 로직을 두어 프론트에게 정보를 전달하게 변경했어요.