### PR TITLE
[HC-88] 댓글 수정 및 삭제 기능 구현

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,11 +4,20 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="5b42d689-d7d0-4ba2-a267-4384bfcc2fe3" name="Changes" comment="[HC-104] 게시글 카테고리 유효 검증 추가 및 에러 처리 로직 추가&#10;&#10;### 유효성 검증&#10;&#10;유효한 카테고리는 다음과 같아요.&#10;&#10;자유, 질문, 중고거래, 구인&#10;&#10;상위 4개를 제외한 다른 문자열이 카테고리에 값으로 요청이 오면, 게시글을 생성하지 않아요.&#10;&#10;### 에러 처리&#10;&#10;문제점: 게시글을 찾을 수 없거나, 작성한 게시글의 카테고리가 유효하지 않으면 런타임 에러를 발생하지만 프론트에서는 500번대 에러만 받아요. ControllerAdvice를 통해, 특정 에러가 발생하면 이를 처리하는 로직을 두어 프론트에게 정보를 전달하게 변경했어요.">
-      <change beforePath="$PROJECT_DIR$/.idea/dataSources.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/dataSources.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+    <list default="true" id="5b42d689-d7d0-4ba2-a267-4384bfcc2fe3" name="Changes" comment="[HC-86] 댓글 삭제 기능 구현&#10;&#10;### 댓글 좋아요 엔드 포인트 경로 변경&#10;&#10;기존의 /community/comments/{id}/like 에서 /comments/{id}/like 으로 변경했어요.">
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/dto/CommentUpdateRequest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/dto/CommentUpdateResponse.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/docs/asciidoc/index.adoc" beforeDir="false" afterPath="$PROJECT_DIR$/src/docs/asciidoc/index.adoc" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/controller/CommentController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/controller/CommentController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/domain/Comment.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/domain/Comment.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/service/CommentService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/service/CommentService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/domain/Post.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/domain/Post.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/dto/PostUpdateResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/dto/PostUpdateResponse.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/service/PostService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/service/PostService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -83,21 +92,33 @@
   "keyToString": {
     "Gradle.Build honeycourses-backend-spring.executor": "Run",
     "Gradle.CommentControllerTest.addComment.executor": "Run",
+    "Gradle.CommentControllerTest.deleteComment.executor": "Run",
     "Gradle.CommentControllerTest.executor": "Run",
     "Gradle.CommentControllerTest.findAllCommentsByPostId.executor": "Run",
+    "Gradle.CommentControllerTest.updateComment.executor": "Run",
+    "Gradle.CommentControllerTest.updateComment_exception_noAuth.executor": "Run",
+    "Gradle.CommentControllerTest.updateComment_exception_noContent.executor": "Run",
     "Gradle.CommentServiceTest.executor": "Run",
     "Gradle.CommentServiceTest.likeComment_up.executor": "Run",
+    "Gradle.CommentServiceTest.updateComment.executor": "Run",
+    "Gradle.CommentServiceTest.updateComment_exception_noAuth.executor": "Run",
     "Gradle.CourseServiceTest.executor": "Debug",
     "Gradle.PostControllerTest.addPost.executor": "Run",
     "Gradle.PostControllerTest.addPost_exception_noTitle.executor": "Run",
+    "Gradle.PostControllerTest.deletePost.executor": "Run",
     "Gradle.PostControllerTest.executor": "Run",
+    "Gradle.PostControllerTest.findAllPosts.executor": "Run",
     "Gradle.PostControllerTest.findPost.executor": "Run",
+    "Gradle.PostControllerTest.findPost_exception_invalidId.executor": "Run",
     "Gradle.PostControllerTest.likePost_up.executor": "Run",
+    "Gradle.PostControllerTest.updatePost.executor": "Run",
     "Gradle.PostServiceTest.addPost_exception_invalid_category.executor": "Run",
+    "Gradle.PostServiceTest.deletePost.executor": "Run",
     "Gradle.PostServiceTest.executor": "Run",
     "Gradle.PostServiceTest.likePost.executor": "Run",
     "Gradle.PostServiceTest.likePost_down.executor": "Run",
     "Gradle.PostServiceTest.likePost_up.executor": "Debug",
+    "Gradle.PostServiceTest.updatePost.executor": "Run",
     "Notification.DisplayName-DoNotAsk-Lombok plugin": "Lombok integration problem",
     "Notification.DoNotAsk-Lombok plugin": "true",
     "RequestMappingsPanelOrder0": "0",
@@ -113,7 +134,7 @@
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
     "create.test.in.the.same.root": "true",
-    "git-widget-placeholder": "HC-86--community-update",
+    "git-widget-placeholder": "HC-88--community-comment-delete",
     "ignore.virus.scanning.warn.message": "true",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/pagh/Desktop/honeycourses-backend-spring/build.gradle",
@@ -136,10 +157,11 @@
 }]]></component>
   <component name="RecentsManager">
     <key name="CreateClassDialog.RecentsKey">
+      <recent name="org.wooriverygood.api.comment.dto" />
+      <recent name="org.wooriverygood.api.advice.exception" />
       <recent name="org.wooriverygood.api.exception" />
       <recent name="org.wooriverygood.api.post.dto" />
       <recent name="org.wooriverygood.api.post.repository" />
-      <recent name="org.wooriverygood.api.comment.dto" />
     </key>
     <key name="CreateTestDialog.Recents.Supers">
       <recent name="" />
@@ -149,7 +171,7 @@
       <recent name="org.wooriverygood.api.post.controller" />
     </key>
   </component>
-  <component name="RunManager" selected="Spring Boot.HoneycoursesBackend">
+  <component name="RunManager" selected="Gradle.CommentControllerTest">
     <configuration name="CommentControllerTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
@@ -174,7 +196,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="CommentServiceTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="CommentControllerTest.updateComment_exception_noAuth" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -187,7 +209,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest&quot;" />
+            <option value="&quot;org.wooriverygood.api.comment.controller.CommentControllerTest.updateComment_exception_noAuth&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -198,7 +220,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="CommentServiceTest.likeComment_up" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="CommentServiceTest.updateComment" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -211,7 +233,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest.likeComment_up&quot;" />
+            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest.updateComment&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -222,7 +244,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="PostServiceTest.addPost_exception_invalid_category" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="CommentServiceTest.updateComment_exception_noAuth" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -235,7 +257,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.post.service.PostServiceTest.addPost_exception_invalid_category&quot;" />
+            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest.updateComment_exception_noAuth&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -246,26 +268,37 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="HoneycoursesBackend" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" temporary="true" nameIsGenerated="true">
-      <module name="honeycourses-backend-spring.main" />
-      <option name="SPRING_BOOT_MAIN_CLASS" value="org.wooriverygood.api.HoneycoursesBackend" />
-      <extension name="coverage">
-        <pattern>
-          <option name="PATTERN" value="org.wooriverygood.api.*" />
-          <option name="ENABLED" value="true" />
-        </pattern>
-      </extension>
-      <method v="2">
-        <option name="Make" enabled="true" />
-      </method>
+    <configuration name="PostServiceTest.updatePost" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;org.wooriverygood.api.post.service.PostServiceTest.updatePost&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Spring Boot.HoneycoursesBackend" />
-        <item itemvalue="Gradle.PostServiceTest.addPost_exception_invalid_category" />
         <item itemvalue="Gradle.CommentControllerTest" />
-        <item itemvalue="Gradle.CommentServiceTest" />
-        <item itemvalue="Gradle.CommentServiceTest.likeComment_up" />
+        <item itemvalue="Gradle.CommentServiceTest.updateComment" />
+        <item itemvalue="Gradle.CommentServiceTest.updateComment_exception_noAuth" />
+        <item itemvalue="Gradle.PostServiceTest.updatePost" />
+        <item itemvalue="Gradle.CommentControllerTest.updateComment_exception_noAuth" />
       </list>
     </recent_temporary>
   </component>
@@ -466,7 +499,31 @@
       <option name="project" value="LOCAL" />
       <updated>1705670920174</updated>
     </task>
-    <option name="localTasksCounter" value="23" />
+    <task id="LOCAL-00023" summary="[HC-86] 게시글 삭제 기능 구현&#10;&#10;### 테스트 코드 수정&#10;&#10;Mock.when 시, 패러미터로 any()를 할당 안해서 adoc 문서에 Response 객체가 안 나타나는 현상 해결했어요.&#10;&#10;### CourseNotFoundException 위치 이동&#10;&#10;advice/exception 폴더로 이동했어요.">
+      <option name="closed" value="true" />
+      <created>1705682677355</created>
+      <option name="number" value="00023" />
+      <option name="presentableId" value="LOCAL-00023" />
+      <option name="project" value="LOCAL" />
+      <updated>1705682677355</updated>
+    </task>
+    <task id="LOCAL-00024" summary="[HC-86] 테스트 코드 수정&#10;&#10;PostServiceTest의 deletePost 메서드에서 CommentRepository를 사용하기 때문에 추가했어요.">
+      <option name="closed" value="true" />
+      <created>1705683542552</created>
+      <option name="number" value="00024" />
+      <option name="presentableId" value="LOCAL-00024" />
+      <option name="project" value="LOCAL" />
+      <updated>1705683542552</updated>
+    </task>
+    <task id="LOCAL-00025" summary="[HC-86] 댓글 삭제 기능 구현&#10;&#10;### 댓글 좋아요 엔드 포인트 경로 변경&#10;&#10;기존의 /community/comments/{id}/like 에서 /comments/{id}/like 으로 변경했어요.">
+      <option name="closed" value="true" />
+      <created>1705751775137</created>
+      <option name="number" value="00025" />
+      <option name="presentableId" value="LOCAL-00025" />
+      <option name="project" value="LOCAL" />
+      <updated>1705751775137</updated>
+    </task>
+    <option name="localTasksCounter" value="26" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -506,7 +563,10 @@
     <MESSAGE value="[HC-74] 게시글 좋아요 기능 구현&#10;&#10;#### 서비스 테스트 코드&#10;&#10;현재 서비스 테스트 코드는 `@SpringBootTest`으로 인해 스프링 컨테이너를 띄우고 실행한다. 단위 테스트만 작성하기 때문에 비효율적이므로, `@ExtendWith(MockitoExtension.class)`으로 테스트 관련 객체들만 mock하여 테스트 속도를 더욱 빠르게 할 수 있음." />
     <MESSAGE value="[HC-75] 댓글 컨틀로러, 서비스 테스트 코드 수정" />
     <MESSAGE value="[HC-104] 게시글 카테고리 유효 검증 추가 및 에러 처리 로직 추가&#10;&#10;### 유효성 검증&#10;&#10;유효한 카테고리는 다음과 같아요.&#10;&#10;자유, 질문, 중고거래, 구인&#10;&#10;상위 4개를 제외한 다른 문자열이 카테고리에 값으로 요청이 오면, 게시글을 생성하지 않아요.&#10;&#10;### 에러 처리&#10;&#10;문제점: 게시글을 찾을 수 없거나, 작성한 게시글의 카테고리가 유효하지 않으면 런타임 에러를 발생하지만 프론트에서는 500번대 에러만 받아요. ControllerAdvice를 통해, 특정 에러가 발생하면 이를 처리하는 로직을 두어 프론트에게 정보를 전달하게 변경했어요." />
-    <option name="LAST_COMMIT_MESSAGE" value="[HC-104] 게시글 카테고리 유효 검증 추가 및 에러 처리 로직 추가&#10;&#10;### 유효성 검증&#10;&#10;유효한 카테고리는 다음과 같아요.&#10;&#10;자유, 질문, 중고거래, 구인&#10;&#10;상위 4개를 제외한 다른 문자열이 카테고리에 값으로 요청이 오면, 게시글을 생성하지 않아요.&#10;&#10;### 에러 처리&#10;&#10;문제점: 게시글을 찾을 수 없거나, 작성한 게시글의 카테고리가 유효하지 않으면 런타임 에러를 발생하지만 프론트에서는 500번대 에러만 받아요. ControllerAdvice를 통해, 특정 에러가 발생하면 이를 처리하는 로직을 두어 프론트에게 정보를 전달하게 변경했어요." />
+    <MESSAGE value="[HC-86] 게시글 삭제 기능 구현&#10;&#10;### 테스트 코드 수정&#10;&#10;Mock.when 시, 패러미터로 any()를 할당 안해서 adoc 문서에 Response 객체가 안 나타나는 현상 해결했어요.&#10;&#10;### CourseNotFoundException 위치 이동&#10;&#10;advice/exception 폴더로 이동했어요." />
+    <MESSAGE value="[HC-86] 테스트 코드 수정&#10;&#10;PostServiceTest의 deletePost 메서드에서 CommentRepository를 사용하기 때문에 추가했어요." />
+    <MESSAGE value="[HC-86] 댓글 삭제 기능 구현&#10;&#10;### 댓글 좋아요 엔드 포인트 경로 변경&#10;&#10;기존의 /community/comments/{id}/like 에서 /comments/{id}/like 으로 변경했어요." />
+    <option name="LAST_COMMIT_MESSAGE" value="[HC-86] 댓글 삭제 기능 구현&#10;&#10;### 댓글 좋아요 엔드 포인트 경로 변경&#10;&#10;기존의 /community/comments/{id}/like 에서 /comments/{id}/like 으로 변경했어요." />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -82,6 +82,15 @@ operation::comments/create/success[snippets='http-request,http-response']
 ==== 성공
 operation::comments/like/success[snippets='http-request,http-response']
 
+=== 댓글 수정 (PUT / comments/{id})
+==== 성공
+operation::comments/update/success[snippets='http-request,http-response']
+==== 실패
+===== 권한이 없는 경우
+operation::comments/update/fail/noAuth[snippets='http-request,http-response']
+===== 내용이 없는 경우
+operation::comments/update/fail/noContent[snippets='http-request,http-response']
+
 === 댓글 삭제 (DELETE /comments/{id})
 ==== 성공
 operation::comments/delete/success[snippets='http-request,http-response']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -65,6 +65,7 @@ operation::post/update/fail/noTitle[snippets='http-request,http-response']
 ==== 성공
 operation::post/delete/success[snippets='http-request,http-response']
 ==== 실패
+===== 권한이 없는 경우
 operation::post/delete/fail/noAuth[snippets='http-request,http-response']
 
 == 댓글 관리
@@ -77,6 +78,13 @@ operation::comments/find/success[snippets='http-request,http-response']
 ==== 성공
 operation::comments/create/success[snippets='http-request,http-response']
 
-=== 댓글 좋아요 (PUT /community/comments/{id}/like)
+=== 댓글 좋아요 (PUT /comments/{id}/like)
 ==== 성공
 operation::comments/like/success[snippets='http-request,http-response']
+
+=== 댓글 삭제 (DELETE /comments/{id})
+==== 성공
+operation::comments/delete/success[snippets='http-request,http-response']
+==== 실패
+===== 권한이 없는 경우
+operation::comments/delete/fail/noAuth[snippets='http-request,http-response']

--- a/src/main/java/org/wooriverygood/api/comment/controller/CommentController.java
+++ b/src/main/java/org/wooriverygood/api/comment/controller/CommentController.java
@@ -4,10 +4,7 @@ import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.wooriverygood.api.comment.dto.CommentLikeResponse;
-import org.wooriverygood.api.comment.dto.CommentResponse;
-import org.wooriverygood.api.comment.dto.NewCommentRequest;
-import org.wooriverygood.api.comment.dto.NewCommentResponse;
+import org.wooriverygood.api.comment.dto.*;
 import org.wooriverygood.api.comment.service.CommentService;
 import org.wooriverygood.api.support.AuthInfo;
 import org.wooriverygood.api.support.Login;
@@ -38,11 +35,18 @@ public class CommentController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/community/comments/{id}/like")
+    @PutMapping("/comments/{id}/like")
     public ResponseEntity<CommentLikeResponse> likeComment(@PathVariable("id") Long commentId,
                                                            @Login AuthInfo authInfo) {
         CommentLikeResponse response = commentService.likeComment(commentId, authInfo);
-        return ResponseEntity.ok().body(response);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/comments/{id}")
+    public ResponseEntity<CommentDeleteResponse> deleteComment(@PathVariable("id") Long commentId,
+                                              @Login AuthInfo authInfo) {
+        CommentDeleteResponse response = commentService.deleteComment(commentId, authInfo);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/org/wooriverygood/api/comment/controller/CommentController.java
+++ b/src/main/java/org/wooriverygood/api/comment/controller/CommentController.java
@@ -42,6 +42,14 @@ public class CommentController {
         return ResponseEntity.ok(response);
     }
 
+    @PutMapping("/comments/{id}")
+    public ResponseEntity<CommentUpdateResponse> updateComment(@PathVariable("id") Long commentId,
+                                                               @Valid @RequestBody CommentUpdateRequest request,
+                                                               @Login AuthInfo authInfo) {
+        CommentUpdateResponse response = commentService.updateComment(commentId, request, authInfo);
+        return ResponseEntity.ok(response);
+    }
+
     @DeleteMapping("/comments/{id}")
     public ResponseEntity<CommentDeleteResponse> deleteComment(@PathVariable("id") Long commentId,
                                               @Login AuthInfo authInfo) {

--- a/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
+++ b/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.wooriverygood.api.advice.exception.AuthorizationException;
 import org.wooriverygood.api.post.domain.Post;
 
 import java.time.LocalDateTime;
@@ -62,6 +63,10 @@ public class Comment {
     public void deleteCommentLike(CommentLike commentLike) {
         commentLikes.remove(commentLike);
         commentLike.delete();
+    }
+
+    public void validateAuthor(String author) {
+        if (!this.author.equals(author)) throw new AuthorizationException();
     }
 
 }

--- a/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
+++ b/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
@@ -69,4 +69,7 @@ public class Comment {
         if (!this.author.equals(author)) throw new AuthorizationException();
     }
 
+    public void updateContent(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/org/wooriverygood/api/comment/dto/CommentDeleteResponse.java
+++ b/src/main/java/org/wooriverygood/api/comment/dto/CommentDeleteResponse.java
@@ -1,0 +1,15 @@
+package org.wooriverygood.api.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentDeleteResponse {
+
+    private final Long comment_id;
+
+    @Builder
+    public CommentDeleteResponse(Long comment_id) {
+        this.comment_id = comment_id;
+    }
+}

--- a/src/main/java/org/wooriverygood/api/comment/dto/CommentUpdateRequest.java
+++ b/src/main/java/org/wooriverygood/api/comment/dto/CommentUpdateRequest.java
@@ -1,0 +1,19 @@
+package org.wooriverygood.api.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentUpdateRequest {
+
+    @NotBlank(message = "댓글의 내용이 없습니다.")
+    private String content;
+
+    @Builder
+    public CommentUpdateRequest(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/org/wooriverygood/api/comment/dto/CommentUpdateResponse.java
+++ b/src/main/java/org/wooriverygood/api/comment/dto/CommentUpdateResponse.java
@@ -1,0 +1,15 @@
+package org.wooriverygood.api.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CommentUpdateResponse {
+
+    private final Long comment_id;
+
+    @Builder
+    public CommentUpdateResponse(Long comment_id) {
+        this.comment_id = comment_id;
+    }
+}

--- a/src/main/java/org/wooriverygood/api/comment/repository/CommentLikeRepository.java
+++ b/src/main/java/org/wooriverygood/api/comment/repository/CommentLikeRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
 
     Optional<CommentLike> findByCommentAndUsername(Comment comment, String username);
+
+    void deleteAllByComment(Comment comment);
 }

--- a/src/main/java/org/wooriverygood/api/comment/service/CommentService.java
+++ b/src/main/java/org/wooriverygood/api/comment/service/CommentService.java
@@ -4,10 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.wooriverygood.api.comment.domain.Comment;
 import org.wooriverygood.api.comment.domain.CommentLike;
-import org.wooriverygood.api.comment.dto.CommentLikeResponse;
-import org.wooriverygood.api.comment.dto.CommentResponse;
-import org.wooriverygood.api.comment.dto.NewCommentRequest;
-import org.wooriverygood.api.comment.dto.NewCommentResponse;
+import org.wooriverygood.api.comment.dto.*;
 import org.wooriverygood.api.comment.repository.CommentLikeRepository;
 import org.wooriverygood.api.comment.repository.CommentRepository;
 import org.wooriverygood.api.advice.exception.CommentNotFoundException;
@@ -95,6 +92,21 @@ public class CommentService {
         return CommentLikeResponse.builder()
                 .like_count(likeCount)
                 .liked(liked)
+                .build();
+    }
+
+    @Transactional
+    public CommentDeleteResponse deleteComment(Long commentId, AuthInfo authInfo) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(CommentNotFoundException::new);
+
+        comment.validateAuthor(authInfo.getUsername());
+
+        commentLikeRepository.deleteAllByComment(comment);
+        commentRepository.delete(comment);
+
+        return CommentDeleteResponse.builder()
+                .comment_id(commentId)
                 .build();
     }
 }

--- a/src/main/java/org/wooriverygood/api/comment/service/CommentService.java
+++ b/src/main/java/org/wooriverygood/api/comment/service/CommentService.java
@@ -96,6 +96,19 @@ public class CommentService {
     }
 
     @Transactional
+    public CommentUpdateResponse updateComment(Long commentId, CommentUpdateRequest request, AuthInfo authInfo) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(CommentNotFoundException::new);
+        comment.validateAuthor(authInfo.getUsername());
+
+        comment.updateContent(request.getContent());
+
+        return CommentUpdateResponse.builder()
+                .comment_id(comment.getId())
+                .build();
+    }
+
+    @Transactional
     public CommentDeleteResponse deleteComment(Long commentId, AuthInfo authInfo) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(CommentNotFoundException::new);
@@ -109,4 +122,5 @@ public class CommentService {
                 .comment_id(commentId)
                 .build();
     }
+
 }

--- a/src/main/java/org/wooriverygood/api/post/domain/Post.java
+++ b/src/main/java/org/wooriverygood/api/post/domain/Post.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import org.wooriverygood.api.advice.exception.AuthorizationException;
 import org.wooriverygood.api.comment.domain.Comment;
 
 import java.time.LocalDateTime;
@@ -65,6 +66,10 @@ public class Post {
 
     public boolean isSameAuthor(String author) {
         return this.author.equals(author);
+    }
+
+    public void validateAuthor(String author) {
+        if (!this.author.equals(author)) throw new AuthorizationException();
     }
 
     public void addPostLike(PostLike postLike) {

--- a/src/main/java/org/wooriverygood/api/post/dto/PostUpdateResponse.java
+++ b/src/main/java/org/wooriverygood/api/post/dto/PostUpdateResponse.java
@@ -7,14 +7,10 @@ import lombok.Getter;
 public class PostUpdateResponse {
 
     private final Long post_id;
-    private final String post_title;
-    private final String post_content;
 
 
     @Builder
-    public PostUpdateResponse(Long post_id, String post_title, String post_content) {
+    public PostUpdateResponse(Long post_id) {
         this.post_id = post_id;
-        this.post_title = post_title;
-        this.post_content = post_content;
     }
 }

--- a/src/main/java/org/wooriverygood/api/post/service/PostService.java
+++ b/src/main/java/org/wooriverygood/api/post/service/PostService.java
@@ -2,7 +2,6 @@ package org.wooriverygood.api.post.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.wooriverygood.api.advice.exception.AuthorizationException;
 import org.wooriverygood.api.advice.exception.PostNotFoundException;
 import org.wooriverygood.api.comment.repository.CommentRepository;
 import org.wooriverygood.api.post.domain.Post;
@@ -127,15 +126,13 @@ public class PostService {
     public PostUpdateResponse updatePost(Long postId, PostUpdateRequest postUpdateRequest, AuthInfo authInfo) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(PostNotFoundException::new);
-        validateAuthor(authInfo, post);
+        post.validateAuthor(authInfo.getUsername());
 
         post.updateTitle(postUpdateRequest.getPost_title());
         post.updateContent(postUpdateRequest.getPost_content());
 
         return PostUpdateResponse.builder()
                 .post_id(post.getId())
-                .post_title(post.getTitle())
-                .post_content(post.getContent())
                 .build();
     }
 
@@ -143,7 +140,7 @@ public class PostService {
     public PostDeleteResponse deletePost(Long postId, AuthInfo authInfo) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(PostNotFoundException::new);
-        validateAuthor(authInfo, post);
+        post.validateAuthor(authInfo.getUsername());
 
         commentRepository.deleteAllByPost(post);
         postLikeRepository.deleteAllByPost(post);
@@ -153,10 +150,6 @@ public class PostService {
         return PostDeleteResponse.builder()
                 .post_id(postId)
                 .build();
-    }
-
-    private void validateAuthor(AuthInfo authInfo, Post post) {
-        if (!post.isSameAuthor(authInfo.getUsername())) throw new AuthorizationException();
     }
 
 }

--- a/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java
@@ -147,6 +147,39 @@ class CommentServiceTest {
     }
 
     @Test
+    @DisplayName("권한이 있는 댓글을 수정한다.")
+    void updateComment() {
+        CommentUpdateRequest request = CommentUpdateRequest.builder()
+                .content("new comment content")
+                .build();
+
+        Mockito.when(commentRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(singleComment));
+
+        CommentUpdateResponse response = commentService.updateComment(singleComment.getId(), request, authInfo);
+
+        Assertions.assertThat(response.getComment_id()).isEqualTo(singleComment.getId());
+    }
+
+    @Test
+    @DisplayName("권한이 없는 댓글을 수정한다.")
+    void updateComment_exception_noAuth() {
+        CommentUpdateRequest request = CommentUpdateRequest.builder()
+                .content("new comment content")
+                .build();
+        AuthInfo noAuthInfo = AuthInfo.builder()
+                .sub("no")
+                .username("no")
+                .build();
+
+        Mockito.when(commentRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(singleComment));
+
+        Assertions.assertThatThrownBy(() -> commentService.updateComment(singleComment.getId(), request, noAuthInfo))
+                .isInstanceOf(AuthorizationException.class);
+    }
+
+    @Test
     @DisplayName("권한이 있는 댓글을 삭제한다.")
     void deleteComment() {
         Mockito.when(commentRepository.findById(any(Long.class)))

--- a/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java
@@ -9,12 +9,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.wooriverygood.api.advice.exception.AuthorizationException;
 import org.wooriverygood.api.comment.domain.Comment;
 import org.wooriverygood.api.comment.domain.CommentLike;
-import org.wooriverygood.api.comment.dto.CommentLikeResponse;
-import org.wooriverygood.api.comment.dto.CommentResponse;
-import org.wooriverygood.api.comment.dto.NewCommentRequest;
-import org.wooriverygood.api.comment.dto.NewCommentResponse;
+import org.wooriverygood.api.comment.dto.*;
 import org.wooriverygood.api.comment.repository.CommentLikeRepository;
 import org.wooriverygood.api.comment.repository.CommentRepository;
 import org.wooriverygood.api.post.domain.Post;
@@ -146,6 +144,32 @@ class CommentServiceTest {
 
         Assertions.assertThat(response.getLike_count()).isEqualTo(singleComment.getLikeCount() - 1);
         Assertions.assertThat(response.isLiked()).isEqualTo(false);
+    }
+
+    @Test
+    @DisplayName("권한이 있는 댓글을 삭제한다.")
+    void deleteComment() {
+        Mockito.when(commentRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(singleComment));
+
+        CommentDeleteResponse response = commentService.deleteComment(singleComment.getId(), authInfo);
+
+        Assertions.assertThat(response.getComment_id()).isEqualTo(singleComment.getId());
+    }
+
+    @Test
+    @DisplayName("권한이 없는 댓글은 삭제할 수 없다")
+    void deleteComment_exception_noAuth() {
+        Mockito.when(commentRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(singleComment));
+
+        AuthInfo noAuthInfo = AuthInfo.builder()
+                .sub("no")
+                .username("no")
+                .build();
+
+        Assertions.assertThatThrownBy(() -> commentService.deleteComment(singleComment.getId(), noAuthInfo))
+                .isInstanceOf(AuthorizationException.class);
     }
 
 }

--- a/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java
+++ b/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java
@@ -211,8 +211,6 @@ class PostControllerTest extends ControllerTest {
         Mockito.when(postService.updatePost(any(Long.class), any(PostUpdateRequest.class), any(AuthInfo.class)))
                         .thenReturn(PostUpdateResponse.builder()
                                 .post_id((long) 1)
-                                .post_title(request.getPost_title())
-                                .post_content(request.getPost_content())
                                 .build());
 
         restDocs
@@ -228,7 +226,7 @@ class PostControllerTest extends ControllerTest {
 
     @Test
     @DisplayName("권한이 없는 게시글을 수정하면 403을 반환한다.")
-    void updatePost_exception_forbidden() {
+    void updatePost_exception_noAuth() {
         PostUpdateRequest request = PostUpdateRequest.builder()
                 .post_title("new title")
                 .post_content("new content")
@@ -250,7 +248,7 @@ class PostControllerTest extends ControllerTest {
 
     @DisplayName("게시물 수정 시, 제목에 내용이 없는 경우 400을 반환한다.")
     @Test
-    void updatePost_Exception_NoContentTitle() {
+    void updatePost_exception_noTitle() {
         PostUpdateRequest postUpdateRequest = PostUpdateRequest.builder()
                 .post_content("content")
                 .build();

--- a/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java
@@ -207,30 +207,21 @@ class PostServiceTest {
                 .post_content("new content")
                 .build();
 
-        Mockito.when(postRepository.findById(singlePost.getId()))
-                .thenReturn(Optional.ofNullable(Post.builder()
-                        .id(singlePost.getId())
-                        .category(singlePost.getCategory())
-                        .title(request.getPost_title())
-                        .content(request.getPost_content())
-                        .author(singlePost.getAuthor())
-                        .comments(singlePost.getComments())
-                        .postLikes(singlePost.getPostLikes())
-                        .build()));
+        Mockito.when(postRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(singlePost));
 
         PostUpdateResponse response = postService.updatePost(singlePost.getId(), request, authInfo);
 
         Assertions.assertThat(response.getPost_id()).isEqualTo(singlePost.getId());
-        Assertions.assertThat(response.getPost_title()).isEqualTo(request.getPost_title());
-        Assertions.assertThat(response.getPost_content()).isEqualTo(request.getPost_content());
     }
 
     @Test
-    @DisplayName("권한이 없는 게시글을 수정한다.")
+    @DisplayName("권한이 없는 게시글을 수정할 수 없다.")
     void updatePost_exception_noAuth() {
         PostUpdateRequest request = PostUpdateRequest.builder()
                 .post_title("new title")
-                .post_content("new content").build();
+                .post_content("new content")
+                .build();
 
         Mockito.when(postRepository.findById(any(Long.class)))
                 .thenReturn(Optional.ofNullable(noAuthPost));


### PR DESCRIPTION
### 댓글 좋아요 엔드 포인트 경로 변경

기존의 /community/comments/{id}/like 에서 /comments/{id}/like 으로 변경했어요.

### 게시글 수정 응답 객체 변경

기존 응답 객체엔 게시글 제목이랑 내용과 같은 정보를 담아 전달했어요. 하지만 게시글의 좋아요나 댓글 정보도 수정하는 사이에 변경할 수 있다고 생각이 들어서, 게시글 id만 반환하도록 했어요. 해당 id를 통해 게시글 정보를 불러와 갱신하면 게시글 정보의 일관성을 유지할 수 있다고 생각하여 변경했어요.