### PR TITLE
[HC-127] /docs/index.html에 API 명세 배포 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,3 +71,13 @@ bootJar {
         into 'static/docs'
     }
 }
+
+task copyDocument(type: Copy) { // 생성된 html 파일을 옮긴다
+    dependsOn asciidoctor // Gradle의 asciidoctor Task 이후 수행
+    from file("${asciidoctor.outputDir}")
+    into file("src/main/resources/static/docs")
+}
+
+build {
+    dependsOn copyDocument // build 이후 html 파일 복사
+}

--- a/src/main/java/org/wooriverygood/api/config/SecurityConfig.java
+++ b/src/main/java/org/wooriverygood/api/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizationManagerRequestMatcherRegistry ->
                         authorizationManagerRequestMatcherRegistry
                                 .requestMatchers(HttpMethod.OPTIONS).permitAll()
-                                .requestMatchers("/").permitAll() // 권한이 필요없는 엔드 포인트, 루트만 API 작동 여부 확인을 위해 열어둠
+                                .requestMatchers("/", "/docs/**").permitAll() // 권한이 필요없는 엔드 포인트, 루트와 API 명세 엔드포인트 열어둠
                                 .anyRequest().authenticated())
                 .oauth2ResourceServer(httpSecurityOAuth2ResourceServerConfigurer ->
                         httpSecurityOAuth2ResourceServerConfigurer.jwt(jwtConfigurer ->


### PR DESCRIPTION
- 이제 api 루트/docs/index.html에 가면 API 명세 열람 가능.