### PR TITLE
[HC-129] 대댓글 기능 구현

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,18 +4,12 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="5b42d689-d7d0-4ba2-a267-4384bfcc2fe3" name="Changes" comment="[HC-86] 댓글 삭제 기능 구현&#10;&#10;### 댓글 좋아요 엔드 포인트 경로 변경&#10;&#10;기존의 /community/comments/{id}/like 에서 /comments/{id}/like 으로 변경했어요.">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/controller/CommentController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/controller/CommentController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/dto/CommentResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/dto/CommentResponse.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/repository/CommentLikeRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/repository/CommentLikeRepository.java" afterDir="false" />
+    <list default="true" id="5b42d689-d7d0-4ba2-a267-4384bfcc2fe3" name="Changes" comment="[HC-129] 대댓글 삭제 기능 구현&#10;&#10;부모 댓글이 삭제되지 않은 상태에서 대댓글을 삭제하면 대댓글만 삭제돼요.&#10;&#10;만약 대댓글이 달린 부모 댓글을 삭제하면, 부모 댓글의 softRemoved 필드값이 true가 되며, 달려있는 대댓글이 모두 삭제되기 전까지 부모 댓글은 삭제되지 않아요. 하지만 댓글 내용을 알 수 없어요.&#10;&#10;#### 게시글 조회&#10;&#10;게시글 조회 시, 대댓글 개수도 총 댓글 개수에 포함돼요.">
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/domain/Comment.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/domain/Comment.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/service/CommentService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/service/CommentService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/dto/PostResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/dto/PostResponse.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/repository/PostLikeRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/repository/PostLikeRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/service/PostService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/service/PostService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/config/SecurityConfig.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/config/SecurityConfig.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -90,12 +84,18 @@
   "keyToString": {
     "Gradle.Build honeycourses-backend-spring.executor": "Run",
     "Gradle.CommentControllerTest.addComment.executor": "Run",
+    "Gradle.CommentControllerTest.addReply.executor": "Run",
     "Gradle.CommentControllerTest.deleteComment.executor": "Run",
     "Gradle.CommentControllerTest.executor": "Run",
     "Gradle.CommentControllerTest.findAllCommentsByPostId.executor": "Run",
     "Gradle.CommentControllerTest.updateComment.executor": "Run",
     "Gradle.CommentControllerTest.updateComment_exception_noAuth.executor": "Run",
     "Gradle.CommentControllerTest.updateComment_exception_noContent.executor": "Run",
+    "Gradle.CommentServiceTest.addReply.executor": "Run",
+    "Gradle.CommentServiceTest.addReply_exception_depth.executor": "Run",
+    "Gradle.CommentServiceTest.deletePrentAndReply.executor": "Run",
+    "Gradle.CommentServiceTest.deleteReply.executor": "Run",
+    "Gradle.CommentServiceTest.deleteReply_keep_parent.executor": "Run",
     "Gradle.CommentServiceTest.executor": "Run",
     "Gradle.CommentServiceTest.likeComment_up.executor": "Run",
     "Gradle.CommentServiceTest.updateComment.executor": "Run",
@@ -127,12 +127,12 @@
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
     "Shell Script.gradlew.executor": "Run",
-    "Spring Boot.HoneycoursesBackend.executor": "Run",
+    "Spring Boot.HoneycoursesBackend.executor": "Debug",
     "WebServerToolWindowFactoryState": "false",
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
     "create.test.in.the.same.root": "true",
-    "git-widget-placeholder": "HC-119-post-comment-like",
+    "git-widget-placeholder": "HC-129-comments-reply",
     "ignore.virus.scanning.warn.message": "true",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/pagh/Desktop/honeycourses-backend-spring/build.gradle",
@@ -194,7 +194,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="CommentServiceTest.updateComment" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="CommentServiceTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -207,7 +207,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest.updateComment&quot;" />
+            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -218,7 +218,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="CommentServiceTest.updateComment_exception_noAuth" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="CommentServiceTest.deletePrentAndReply" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -231,7 +231,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest.updateComment_exception_noAuth&quot;" />
+            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest.deletePrentAndReply&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -242,7 +242,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="PostControllerTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="CommentServiceTest.deleteReply" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -255,7 +255,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.post.controller.PostControllerTest&quot;" />
+            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest.deleteReply&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -266,26 +266,37 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="HoneycoursesBackend" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" temporary="true" nameIsGenerated="true">
-      <module name="honeycourses-backend-spring.main" />
-      <option name="SPRING_BOOT_MAIN_CLASS" value="org.wooriverygood.api.HoneycoursesBackend" />
-      <extension name="coverage">
-        <pattern>
-          <option name="PATTERN" value="org.wooriverygood.api.*" />
-          <option name="ENABLED" value="true" />
-        </pattern>
-      </extension>
-      <method v="2">
-        <option name="Make" enabled="true" />
-      </method>
+    <configuration name="CommentServiceTest.deleteReply_keep_parent" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest.deleteReply_keep_parent&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
     </configuration>
     <recent_temporary>
       <list>
         <item itemvalue="Gradle.CommentControllerTest" />
-        <item itemvalue="Gradle.PostControllerTest" />
-        <item itemvalue="Spring Boot.HoneycoursesBackend" />
-        <item itemvalue="Gradle.CommentServiceTest.updateComment" />
-        <item itemvalue="Gradle.CommentServiceTest.updateComment_exception_noAuth" />
+        <item itemvalue="Gradle.CommentServiceTest.deletePrentAndReply" />
+        <item itemvalue="Gradle.CommentServiceTest.deleteReply_keep_parent" />
+        <item itemvalue="Gradle.CommentServiceTest" />
+        <item itemvalue="Gradle.CommentServiceTest.deleteReply" />
       </list>
     </recent_temporary>
   </component>
@@ -510,7 +521,31 @@
       <option name="project" value="LOCAL" />
       <updated>1705751775137</updated>
     </task>
-    <option name="localTasksCounter" value="26" />
+    <task id="LOCAL-00026" summary="[HC-129] 지연 로딩 적용">
+      <option name="closed" value="true" />
+      <created>1705951323612</created>
+      <option name="number" value="00026" />
+      <option name="presentableId" value="LOCAL-00026" />
+      <option name="project" value="LOCAL" />
+      <updated>1705951323612</updated>
+    </task>
+    <task id="LOCAL-00027" summary="[HC-129] 대댓글 작성 기능 구현&#10;&#10;댓글과 대댓글 모두 Comment 객체로 처리했어요.&#10;&#10;- Comment 클래스에 parent, children 필드 추가&#10;&#10;일반 댓글은 parent 필드 값이 null 이며, childrent 필드에는 대댓글 객체들이 들어가요.&#10;&#10;따라서 대댓글은 모두 같은 부모 댓글을 바라보며, 대댓글의 대댓글은 불가능해요.">
+      <option name="closed" value="true" />
+      <created>1706040434040</created>
+      <option name="number" value="00027" />
+      <option name="presentableId" value="LOCAL-00027" />
+      <option name="project" value="LOCAL" />
+      <updated>1706040434040</updated>
+    </task>
+    <task id="LOCAL-00028" summary="[HC-129] 대댓글 삭제 기능 구현&#10;&#10;부모 댓글이 삭제되지 않은 상태에서 대댓글을 삭제하면 대댓글만 삭제돼요.&#10;&#10;만약 대댓글이 달린 부모 댓글을 삭제하면, 부모 댓글의 softRemoved 필드값이 true가 되며, 달려있는 대댓글이 모두 삭제되기 전까지 부모 댓글은 삭제되지 않아요. 하지만 댓글 내용을 알 수 없어요.&#10;&#10;#### 게시글 조회&#10;&#10;게시글 조회 시, 대댓글 개수도 총 댓글 개수에 포함돼요.">
+      <option name="closed" value="true" />
+      <created>1706042871509</created>
+      <option name="number" value="00028" />
+      <option name="presentableId" value="LOCAL-00028" />
+      <option name="project" value="LOCAL" />
+      <updated>1706042871509</updated>
+    </task>
+    <option name="localTasksCounter" value="29" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -528,9 +563,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="project init" />
-    <MESSAGE value="commit test" />
-    <MESSAGE value="feat. /api/courses get 기능" />
     <MESSAGE value="[HC-68] 커뮤니티 패키지 구성&#10;&#10;- 게시글 도메인 객체(Post)를 부분적으로 구성&#10;- 작성자, 댓글, 좋아요 관련은 추후 구현 예정" />
     <MESSAGE value="[HC-68] 모든 게시글 불러오기 기능 구현" />
     <MESSAGE value="[HC-68] 특정 게시글 정보 조회 기능 구현&#10;&#10;- Post 패키지명에 따라서 이름 변경" />
@@ -553,7 +585,10 @@
     <MESSAGE value="[HC-86] 게시글 삭제 기능 구현&#10;&#10;### 테스트 코드 수정&#10;&#10;Mock.when 시, 패러미터로 any()를 할당 안해서 adoc 문서에 Response 객체가 안 나타나는 현상 해결했어요.&#10;&#10;### CourseNotFoundException 위치 이동&#10;&#10;advice/exception 폴더로 이동했어요." />
     <MESSAGE value="[HC-86] 테스트 코드 수정&#10;&#10;PostServiceTest의 deletePost 메서드에서 CommentRepository를 사용하기 때문에 추가했어요." />
     <MESSAGE value="[HC-86] 댓글 삭제 기능 구현&#10;&#10;### 댓글 좋아요 엔드 포인트 경로 변경&#10;&#10;기존의 /community/comments/{id}/like 에서 /comments/{id}/like 으로 변경했어요." />
-    <option name="LAST_COMMIT_MESSAGE" value="[HC-86] 댓글 삭제 기능 구현&#10;&#10;### 댓글 좋아요 엔드 포인트 경로 변경&#10;&#10;기존의 /community/comments/{id}/like 에서 /comments/{id}/like 으로 변경했어요." />
+    <MESSAGE value="[HC-129] 지연 로딩 적용" />
+    <MESSAGE value="[HC-129] 대댓글 작성 기능 구현&#10;&#10;댓글과 대댓글 모두 Comment 객체로 처리했어요.&#10;&#10;- Comment 클래스에 parent, children 필드 추가&#10;&#10;일반 댓글은 parent 필드 값이 null 이며, childrent 필드에는 대댓글 객체들이 들어가요.&#10;&#10;따라서 대댓글은 모두 같은 부모 댓글을 바라보며, 대댓글의 대댓글은 불가능해요." />
+    <MESSAGE value="[HC-129] 대댓글 삭제 기능 구현&#10;&#10;부모 댓글이 삭제되지 않은 상태에서 대댓글을 삭제하면 대댓글만 삭제돼요.&#10;&#10;만약 대댓글이 달린 부모 댓글을 삭제하면, 부모 댓글의 softRemoved 필드값이 true가 되며, 달려있는 대댓글이 모두 삭제되기 전까지 부모 댓글은 삭제되지 않아요. 하지만 댓글 내용을 알 수 없어요.&#10;&#10;#### 게시글 조회&#10;&#10;게시글 조회 시, 대댓글 개수도 총 댓글 개수에 포함돼요." />
+    <option name="LAST_COMMIT_MESSAGE" value="[HC-129] 대댓글 삭제 기능 구현&#10;&#10;부모 댓글이 삭제되지 않은 상태에서 대댓글을 삭제하면 대댓글만 삭제돼요.&#10;&#10;만약 대댓글이 달린 부모 댓글을 삭제하면, 부모 댓글의 softRemoved 필드값이 true가 되며, 달려있는 대댓글이 모두 삭제되기 전까지 부모 댓글은 삭제되지 않아요. 하지만 댓글 내용을 알 수 없어요.&#10;&#10;#### 게시글 조회&#10;&#10;게시글 조회 시, 대댓글 개수도 총 댓글 개수에 포함돼요." />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -129,3 +129,6 @@ operation::comments/delete/fail/noAuth[snippets='http-request,http-response']
 === 특정 댓글의 대댓글 작성하기 (POST /comments/{id}/reply)
 ==== 성공
 operation::reply/create/success[snippets='http-request,http-response']
+==== 실패
+===== 대댓글에 작성하는 경우
+operation::reply/create/fail/depth[snippets='http-request,http-response']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -125,3 +125,7 @@ operation::comments/delete/success[snippets='http-request,http-response']
 ==== 실패
 ===== 권한이 없는 경우
 operation::comments/delete/fail/noAuth[snippets='http-request,http-response']
+
+=== 특정 댓글의 대댓글 작성하기 (POST /comments/{id}/reply)
+==== 성공
+operation::reply/create/success[snippets='http-request,http-response']

--- a/src/main/java/org/wooriverygood/api/advice/exception/ReplyDepthException.java
+++ b/src/main/java/org/wooriverygood/api/advice/exception/ReplyDepthException.java
@@ -1,0 +1,12 @@
+package org.wooriverygood.api.advice.exception;
+
+import org.wooriverygood.api.advice.exception.general.BadRequestException;
+
+public class ReplyDepthException extends BadRequestException {
+
+    private static final String MESSAGE = "대댓글에 답글을 달 수 없습니다.";
+
+    public ReplyDepthException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/org/wooriverygood/api/comment/controller/CommentController.java
+++ b/src/main/java/org/wooriverygood/api/comment/controller/CommentController.java
@@ -58,4 +58,12 @@ public class CommentController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/comments/{id}/reply")
+    public ResponseEntity<Void> addReply(@PathVariable("id") Long commentId,
+                                         @RequestBody NewReplyRequest request,
+                                         @Login AuthInfo authInfo) {
+        commentService.addReply(commentId, request, authInfo);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
 }

--- a/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
+++ b/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
@@ -55,14 +55,17 @@ public class Comment {
     @CreatedDate
     private LocalDateTime createdAt;
 
+    private boolean softRemoved;
+
     @Builder
-    public Comment(Long id, String content, String author, Post post, Comment parent, List<CommentLike> commentLikes) {
+    public Comment(Long id, String content, String author, Post post, Comment parent, List<CommentLike> commentLikes, boolean softRemoved) {
         this.id = id;
         this.content = content;
         this.author = author;
         this.post = post;
         this.parent = parent;
         this.commentLikes = commentLikes;
+        this.softRemoved = softRemoved;
     }
 
     public void addCommentLike(CommentLike commentLike) {
@@ -84,6 +87,31 @@ public class Comment {
 
     public void addChildren(Comment reply) {
         children.add(reply);
+    }
+
+    public void deleteChild(Comment reply) {
+        children.remove(reply);
+        reply.delete();
+    }
+
+    public void delete() {
+        parent = null;
+    }
+
+    public boolean isParent() {
+        return Objects.isNull(parent);
+    }
+
+    public boolean hasNoReply() {
+        return children.isEmpty();
+    }
+
+    public void willBeDeleted() {
+        softRemoved = true;
+    }
+
+    public boolean canDelete() {
+        return hasNoReply() && softRemoved;
     }
 
 }

--- a/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
+++ b/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
@@ -11,7 +11,9 @@ import org.wooriverygood.api.advice.exception.AuthorizationException;
 import org.wooriverygood.api.post.domain.Post;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Table(name = "comments")
@@ -25,6 +27,12 @@ public class Comment {
     @Column(name = "comment_id")
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Comment parent;
+
+    @OneToMany(mappedBy = "parent")
+    private List<Comment> children = new ArrayList<>();
 
     @Column(name = "comment_content", length = 200, nullable = false)
     private String content;
@@ -48,11 +56,12 @@ public class Comment {
     private LocalDateTime createdAt;
 
     @Builder
-    public Comment(Long id, String content, String author, Post post, List<CommentLike> commentLikes) {
+    public Comment(Long id, String content, String author, Post post, Comment parent, List<CommentLike> commentLikes) {
         this.id = id;
         this.content = content;
         this.author = author;
         this.post = post;
+        this.parent = parent;
         this.commentLikes = commentLikes;
     }
 
@@ -72,4 +81,9 @@ public class Comment {
     public void updateContent(String content) {
         this.content = content;
     }
+
+    public void addChildren(Comment reply) {
+        children.add(reply);
+    }
+
 }

--- a/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
+++ b/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
@@ -102,6 +102,10 @@ public class Comment {
         return Objects.isNull(parent);
     }
 
+    public boolean isReply() {
+        return !isParent();
+    }
+
     public boolean hasNoReply() {
         return children.isEmpty();
     }

--- a/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
+++ b/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
@@ -32,7 +32,7 @@ public class Comment {
     @Column(name = "comment_author", length = 1000)
     private String author;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", referencedColumnName = "post_id")
     private Post post;
 

--- a/src/main/java/org/wooriverygood/api/comment/domain/CommentLike.java
+++ b/src/main/java/org/wooriverygood/api/comment/domain/CommentLike.java
@@ -15,7 +15,7 @@ public class CommentLike {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id", referencedColumnName = "comment_id")
     private Comment comment;
 

--- a/src/main/java/org/wooriverygood/api/comment/dto/CommentResponse.java
+++ b/src/main/java/org/wooriverygood/api/comment/dto/CommentResponse.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import org.wooriverygood.api.comment.domain.Comment;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 public class CommentResponse {
@@ -16,10 +17,11 @@ public class CommentResponse {
     private final int comment_likes;
     private final LocalDateTime comment_time;
     private final boolean liked;
+    private final List<ReplyResponse> replies;
 
 
     @Builder
-    public CommentResponse(Long comment_id, String comment_content, String comment_author, Long post_id, int comment_likes, LocalDateTime comment_time, boolean liked) {
+    public CommentResponse(Long comment_id, String comment_content, String comment_author, Long post_id, int comment_likes, LocalDateTime comment_time, boolean liked, List<ReplyResponse> replies) {
         this.comment_id = comment_id;
         this.comment_content = comment_content;
         this.comment_author = comment_author;
@@ -27,10 +29,11 @@ public class CommentResponse {
         this.comment_likes = comment_likes;
         this.comment_time = comment_time;
         this.liked = liked;
+        this.replies = replies;
     }
 
 
-    public static CommentResponse from(Comment comment, boolean liked) {
+    public static CommentResponse from(Comment comment, List<ReplyResponse> replies, boolean liked) {
         return CommentResponse.builder()
                 .comment_id(comment.getId())
                 .comment_content(comment.getContent())
@@ -39,6 +42,19 @@ public class CommentResponse {
                 .comment_likes(comment.getLikeCount())
                 .comment_time(comment.getCreatedAt())
                 .liked(liked)
+                .replies(replies)
+                .build();
+    }
+
+    public static CommentResponse softRemovedFrom(Comment comment, List<ReplyResponse> replies) {
+        return CommentResponse.builder()
+                .comment_id(comment.getId())
+                .comment_content(null)
+                .comment_author(comment.getAuthor())
+                .post_id(comment.getPost().getId())
+                .comment_likes(comment.getLikeCount())
+                .comment_time(comment.getCreatedAt())
+                .replies(replies)
                 .build();
     }
 }

--- a/src/main/java/org/wooriverygood/api/comment/dto/NewReplyRequest.java
+++ b/src/main/java/org/wooriverygood/api/comment/dto/NewReplyRequest.java
@@ -1,0 +1,20 @@
+package org.wooriverygood.api.comment.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class NewReplyRequest {
+
+    @NotBlank(message = "댓글의 내용을 비우면 안됩니다.")
+    private String content;
+
+
+    @Builder
+    public NewReplyRequest(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/org/wooriverygood/api/comment/dto/ReplyResponse.java
+++ b/src/main/java/org/wooriverygood/api/comment/dto/ReplyResponse.java
@@ -1,0 +1,42 @@
+package org.wooriverygood.api.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.wooriverygood.api.comment.domain.Comment;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ReplyResponse {
+
+    private final Long reply_id;
+    private final String reply_content;
+    private final String reply_author;
+    private final int reply_likes;
+    private final LocalDateTime reply_time;
+    private final boolean liked;
+
+
+    @Builder
+
+    public ReplyResponse(Long reply_id, String reply_content, String reply_author, int reply_likes, LocalDateTime reply_time, boolean liked) {
+        this.reply_id = reply_id;
+        this.reply_content = reply_content;
+        this.reply_author = reply_author;
+        this.reply_likes = reply_likes;
+        this.reply_time = reply_time;
+        this.liked = liked;
+    }
+
+    public static ReplyResponse from(Comment reply, boolean liked) {
+        return ReplyResponse.builder()
+                .reply_id(reply.getId())
+                .reply_content(reply.getContent())
+                .reply_author(reply.getAuthor())
+                .reply_likes(reply.getLikeCount())
+                .reply_time(reply.getCreatedAt())
+                .liked(liked)
+                .build();
+    }
+
+}

--- a/src/main/java/org/wooriverygood/api/post/domain/Post.java
+++ b/src/main/java/org/wooriverygood/api/post/domain/Post.java
@@ -84,4 +84,11 @@ public class Post {
     public void updateContent(String content) {
         this.content = content;
     }
+
+    public int getCommentCount() {
+        if (comments == null)
+            return 0;
+        return comments.size();
+    }
+
 }

--- a/src/main/java/org/wooriverygood/api/post/domain/PostCategory.java
+++ b/src/main/java/org/wooriverygood/api/post/domain/PostCategory.java
@@ -17,13 +17,13 @@ public enum PostCategory {
         return this.value.equals(value);
     }
 
-    public static PostCategory parse(String value) throws InvalidPostCategoryException {
+    public static PostCategory parse(String value)  {
         return switch (value) {
             case "자유" -> PostCategory.FREE;
             case "질문" -> PostCategory.QUESTION;
             case "중고거래" -> PostCategory.TRADE;
             case "구인" -> PostCategory.OFFER;
-            default -> throw new InvalidPostCategoryException();
+            default -> null;
         };
     }
 }

--- a/src/main/java/org/wooriverygood/api/post/domain/PostLike.java
+++ b/src/main/java/org/wooriverygood/api/post/domain/PostLike.java
@@ -15,7 +15,7 @@ public class PostLike {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", referencedColumnName = "post_id")
     private Post post;
 

--- a/src/main/java/org/wooriverygood/api/post/dto/PostResponse.java
+++ b/src/main/java/org/wooriverygood/api/post/dto/PostResponse.java
@@ -39,7 +39,7 @@ public class PostResponse {
                 .post_content(post.getContent())
                 .post_category(post.getCategory().getValue())
                 .post_author(post.getAuthor())
-                .post_comments(post.getComments().size())
+                .post_comments(post.getCommentCount())
                 .post_likes(post.getLikeCount())
                 .post_time(post.getCreatedAt())
                 .liked(liked)

--- a/src/main/java/org/wooriverygood/api/post/service/PostService.java
+++ b/src/main/java/org/wooriverygood/api/post/service/PostService.java
@@ -2,6 +2,7 @@ package org.wooriverygood.api.post.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.wooriverygood.api.advice.exception.InvalidPostCategoryException;
 import org.wooriverygood.api.advice.exception.PostNotFoundException;
 import org.wooriverygood.api.comment.repository.CommentRepository;
 import org.wooriverygood.api.post.domain.Post;
@@ -56,7 +57,8 @@ public class PostService {
 
     @Transactional
     public NewPostResponse addPost(AuthInfo authInfo, NewPostRequest newPostRequest) {
-        PostCategory.parse(newPostRequest.getPost_category());
+        if (PostCategory.parse(newPostRequest.getPost_category()) == null)
+            throw new InvalidPostCategoryException();
         Post post = createPost(authInfo, newPostRequest);
         Post saved = postRepository.save(post);
         return createResponse(saved);

--- a/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java
+++ b/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
 
@@ -210,6 +211,27 @@ class CommentControllerTest extends ControllerTest {
                 .assertThat()
                 .apply(document("comments/delete/fail/noAuth"))
                 .statusCode(HttpStatus.FORBIDDEN.value());
+    }
+
+    @Test
+    @DisplayName("특정 댓글의 대댓글을 작성한다.")
+    void addReply() {
+        NewReplyRequest request = NewReplyRequest.builder()
+                .content("reply content")
+                .build();
+
+        doNothing().when(commentService)
+                .addReply(any(Long.class), any(NewReplyRequest.class), any(AuthInfo.class));
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer aws-cognito-access-token")
+                .body(request)
+                .when().post("/comments/3/reply")
+                .then().log().all()
+                .assertThat()
+                .apply(document("reply/create/success"))
+                .statusCode(HttpStatus.CREATED.value());
     }
 
 }

--- a/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java
+++ b/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.wooriverygood.api.advice.exception.AuthorizationException;
+import org.wooriverygood.api.advice.exception.ReplyDepthException;
 import org.wooriverygood.api.comment.dto.*;
 import org.wooriverygood.api.post.domain.Post;
 import org.wooriverygood.api.post.domain.PostCategory;
@@ -19,6 +20,7 @@ import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 
 
@@ -52,7 +54,19 @@ class CommentControllerTest extends ControllerTest {
                     .comment_likes(i + 8)
                     .comment_time(LocalDateTime.now())
                     .liked(false)
+                    .replies(new ArrayList<>())
                     .build());
+        }
+        for (int i = 12; i <= 15; i++) {
+            responses.get(2).getReplies()
+                    .add(ReplyResponse.builder()
+                            .reply_id((long) i)
+                            .reply_content("reply content " + i)
+                            .reply_author("user-" + (i % 2))
+                            .reply_likes(i - 6)
+                            .reply_time(LocalDateTime.now())
+                            .liked(false)
+                            .build());
         }
     }
 
@@ -232,6 +246,27 @@ class CommentControllerTest extends ControllerTest {
                 .assertThat()
                 .apply(document("reply/create/success"))
                 .statusCode(HttpStatus.CREATED.value());
+    }
+
+    @Test
+    @DisplayName("특정 댓글의 대댓글을 작성한다.")
+    void addReply_exception_depth() {
+        NewReplyRequest request = NewReplyRequest.builder()
+                .content("reply content")
+                .build();
+
+        doThrow(new ReplyDepthException()).when(commentService)
+                .addReply(any(Long.class), any(NewReplyRequest.class), any(AuthInfo.class));
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer aws-cognito-access-token")
+                .body(request)
+                .when().post("/comments/3/reply")
+                .then().log().all()
+                .assertThat()
+                .apply(document("reply/create/fail/depth"))
+                .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
 }

--- a/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java
@@ -162,7 +162,7 @@ class CommentServiceTest {
     }
 
     @Test
-    @DisplayName("권한이 없는 댓글을 수정한다.")
+    @DisplayName("권한이 없는 댓글을 수정할 수 없다.")
     void updateComment_exception_noAuth() {
         CommentUpdateRequest request = CommentUpdateRequest.builder()
                 .content("new comment content")
@@ -203,6 +203,23 @@ class CommentServiceTest {
 
         Assertions.assertThatThrownBy(() -> commentService.deleteComment(singleComment.getId(), noAuthInfo))
                 .isInstanceOf(AuthorizationException.class);
+    }
+
+    @Test
+    @DisplayName("특정 댓글의 대댓글을 작성한다.")
+    void addReply() {
+        NewReplyRequest request = NewReplyRequest.builder()
+                .content("reply content")
+                .build();
+
+        Mockito.when(commentRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(singleComment));
+
+        commentService.addReply(singleComment.getId(), request, authInfo);
+        Comment reply = singleComment.getChildren().get(0);
+
+        Assertions.assertThat(reply.getContent()).isEqualTo(request.getContent());
+        Assertions.assertThat(reply.getParent()).isEqualTo(singleComment);
     }
 
 }

--- a/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.wooriverygood.api.advice.exception.AuthorizationException;
+import org.wooriverygood.api.advice.exception.ReplyDepthException;
 import org.wooriverygood.api.comment.domain.Comment;
 import org.wooriverygood.api.comment.domain.CommentLike;
 import org.wooriverygood.api.comment.dto.*;
@@ -68,9 +69,20 @@ class CommentServiceTest {
             .commentLikes(new ArrayList<>())
             .build();
 
+    Comment reply = Comment.builder()
+            .id(3L)
+            .post(singlePost)
+            .content("reply content")
+            .author(authInfo.getUsername())
+            .commentLikes(new ArrayList<>())
+            .parent(singleComment)
+            .build();
+
 
     @BeforeEach
     void setUpPosts() {
+        singleComment.getChildren().add(reply);
+
         for (int i = 0; i < COMMENT_COUNT; i++) {
             Comment comment = Comment.builder()
                     .id((long) i)
@@ -220,6 +232,70 @@ class CommentServiceTest {
 
         Assertions.assertThat(reply.getContent()).isEqualTo(request.getContent());
         Assertions.assertThat(reply.getParent()).isEqualTo(singleComment);
+    }
+
+    @Test
+    @DisplayName("대댓글의 대댓글을 작성할 수 없다.")
+    void addReply_exception_depth() {
+        NewReplyRequest request = NewReplyRequest.builder()
+                .content("reply content")
+                .build();
+
+        Mockito.when(commentRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(reply));
+
+        Assertions.assertThatThrownBy(() -> commentService.addReply(reply.getId(), request, authInfo))
+                .isInstanceOf(ReplyDepthException.class);
+    }
+
+    @Test
+    @DisplayName("권한이 있는 대댓글을 삭제한다.")
+    void deleteReply() {
+        Mockito.when(commentRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(reply));
+
+        CommentDeleteResponse response = commentService.deleteComment(reply.getId(), authInfo);
+
+        Assertions.assertThat(response.getComment_id()).isEqualTo(reply.getId());
+        Assertions.assertThat(singleComment.getChildren().size()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("권한이 없는 대댓글을 삭제할 수 없다.")
+    void deleteReply_exception_noAuth() {
+        Mockito.when(commentRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(reply));
+
+        AuthInfo noAuthInfo = AuthInfo.builder()
+                .sub("no")
+                .username("no")
+                .build();
+
+        Assertions.assertThatThrownBy(() -> commentService.deleteComment(reply.getId(), noAuthInfo))
+                .isInstanceOf(AuthorizationException.class);
+    }
+
+    @Test
+    @DisplayName("부모 댓글을 삭제해도 대댓글은 남아있다.")
+    void deleteComment_keepChildren() {
+        Mockito.when(commentRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(singleComment));
+
+        commentService.deleteComment(singleComment.getId(), authInfo);
+
+        Assertions.assertThat(singleComment.isSoftRemoved()).isEqualTo(true);
+        Assertions.assertThat(singleComment.getChildren().size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("특정 대댓글 삭제 후, 삭제 예정으로 처리되고 대댓글이 없는 부모 댓글을 삭제한다.")
+    void deletePrentAndReply() {
+        singleComment.willBeDeleted();
+        Mockito.when(commentRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(reply));
+        commentService.deleteComment(reply.getId(), authInfo);
+
+        Assertions.assertThat(singleComment.canDelete()).isEqualTo(true);
     }
 
 }


### PR DESCRIPTION
댓글과 대댓글 모두 Comment 객체로 처리했어요.

- Comment 클래스에 parent, children 필드 추가

일반 댓글은 parent 필드 값이 null 이며, childrent 필드에는 대댓글 객체들이 들어가요.

따라서 대댓글은 모두 같은 부모 댓글을 바라보며, 대댓글의 대댓글은 불가능해요.

### 특정 댓글 조회

특정 댓글 조회 시, 응답 객체의 replies 필드에 해당 댓글의 대댓글 응답 객체들이 들어있어요.

### 대댓글 삭제

- 부모 댓글이 삭제되지 않은 상태에서 대댓글을 삭제하면 대댓글만 삭제돼요.

-. 대댓글이 달린 부모 댓글을 삭제하면,

1. 부모 댓글의 softRemoved 필드값이 true가 돼요.
2. 부모 댓글의 대댓글이 모두 삭제되기 전까지 부모 댓글은 삭제되지 않아요. 하지만 부모 댓글의 내용은 null로 반환돼요.

### 게시글 조회

게시글 조회 시 반환하는 총 댓글 개수에 대댓글 개수도 포함해요.

#### 게시글 카테고리 유효성 검증

유효하지 않을 시, PostService에서 InvalidPostCategoryException을 던져요.