### PR TITLE
[HC-140] 게시글 페이지네이션 기능 구현 

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,7 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="5b42d689-d7d0-4ba2-a267-4384bfcc2fe3" name="Changes" comment="[HC-137] 댓글 및 답글 수정 여부 반환 &#10;&#10;댓글 및 답글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요.">
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/dto/PostsResponse.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/domain/Comment.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/domain/Comment.java" afterDir="false" />
+    <list default="true" id="5b42d689-d7d0-4ba2-a267-4384bfcc2fe3" name="Changes" comment="[HC-140] 게시글 페이지네이션 기능 구현 &#10;&#10;## api에 요청 시, 응답 객체 변경 (프론트에서 반영해줘야 함!!!)&#10;&#10;/community?page={pageNo} 에 요청 시, 다음과 같은 응답 객체 반환해요.&#10;&#10;{&#10;  &quot;posts&quot;: [기존 게시글 응답 객체],  // 기본 값으로 10개이며, 해당 페이지의 게시글 개수가 10개 미만이면, 해당하는 개수만큼 들어있어요.&#10;  &quot;totalPageCount&quot;: 3,  // 총 페이지 개수 &#10;  &quot;totalPostCount&quot;: 23  // 총 게시글 개수&#10;}&#10;&#10;- pageNo의 기본값은 0이에요. 만약 최신 게시글 10개만 불러오려면, /community 경로로 요청하면 돼요. 즉, 이 경우에는 물음표 뒤 생략이 가능해요.&#10;&#10;## 예제&#10;&#10;총 23개의 게시글이 존재하면, 총 3개의 페이지로 구분할 수 있어요.&#10;&#10;- 1번째부터 10번째 게시글&#10;- 11번째부터 20번째 게시글&#10;- 21번째부터 23번째 게시글&#10;&#10;따라서, 만약 11번째부터 20번째 게시글을 불러오고 싶으면, api 경로의 pageNo에 1를 넣어줘요. (/community?page=1)">
       <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/config/SecurityConfig.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/config/SecurityConfig.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/controller/PostController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/controller/PostController.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java" afterDir="false" />
@@ -110,6 +107,7 @@
     "Gradle.PostControllerTest.deletePost.executor": "Run",
     "Gradle.PostControllerTest.executor": "Run",
     "Gradle.PostControllerTest.findAllPosts.executor": "Run",
+    "Gradle.PostControllerTest.findMyPosts.executor": "Run",
     "Gradle.PostControllerTest.findPost.executor": "Run",
     "Gradle.PostControllerTest.findPost_exception_invalidId.executor": "Run",
     "Gradle.PostControllerTest.findPosts.executor": "Run",
@@ -119,6 +117,7 @@
     "Gradle.PostServiceTest.deletePost.executor": "Run",
     "Gradle.PostServiceTest.executor": "Run",
     "Gradle.PostServiceTest.findAllPosts_login.executor": "Run",
+    "Gradle.PostServiceTest.findMyPosts.executor": "Run",
     "Gradle.PostServiceTest.likePost.executor": "Run",
     "Gradle.PostServiceTest.likePost_down.executor": "Run",
     "Gradle.PostServiceTest.likePost_up.executor": "Debug",
@@ -138,6 +137,7 @@
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
     "create.test.in.the.same.root": "true",
+    "extract.method.default.visibility": "private",
     "git-widget-placeholder": "HC-140-pagination",
     "ignore.virus.scanning.warn.message": "true",
     "kotlin-language-version-configured": "true",
@@ -175,8 +175,8 @@
       <recent name="org.wooriverygood.api.post.controller" />
     </key>
   </component>
-  <component name="RunManager" selected="Gradle.PostServiceTest.findAllPosts_login">
-    <configuration name="CommentServiceTest.updateComment" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+  <component name="RunManager" selected="Gradle.PostServiceTest.findMyPosts">
+    <configuration name="PostControllerTest.findMyPosts" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -189,7 +189,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest.updateComment&quot;" />
+            <option value="&quot;org.wooriverygood.api.post.controller.PostControllerTest.findMyPosts&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -248,7 +248,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="PostServiceTest.updatePost" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="PostServiceTest.findMyPosts" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -261,7 +261,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.post.service.PostServiceTest.updatePost&quot;" />
+            <option value="&quot;org.wooriverygood.api.post.service.PostServiceTest.findMyPosts&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -287,11 +287,11 @@
     </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Gradle.PostServiceTest.findMyPosts" />
+        <item itemvalue="Gradle.PostControllerTest.findMyPosts" />
         <item itemvalue="Gradle.PostServiceTest.findAllPosts_login" />
         <item itemvalue="Gradle.PostControllerTest.findPosts" />
         <item itemvalue="Spring Boot.HoneycoursesBackend" />
-        <item itemvalue="Gradle.CommentServiceTest.updateComment" />
-        <item itemvalue="Gradle.PostServiceTest.updatePost" />
       </list>
     </recent_temporary>
   </component>
@@ -315,7 +315,7 @@
       <workItem from="1705241248366" duration="871000" />
       <workItem from="1705301106038" duration="464000" />
       <workItem from="1705302176845" duration="9723000" />
-      <workItem from="1706178673625" duration="7475000" />
+      <workItem from="1706178673625" duration="8490000" />
     </task>
     <task id="LOCAL-00001" summary="project init">
       <option name="closed" value="true" />
@@ -557,7 +557,15 @@
       <option name="project" value="LOCAL" />
       <updated>1706179972211</updated>
     </task>
-    <option name="localTasksCounter" value="31" />
+    <task id="LOCAL-00031" summary="[HC-140] 게시글 페이지네이션 기능 구현 &#10;&#10;## api에 요청 시, 응답 객체 변경 (프론트에서 반영해줘야 함!!!)&#10;&#10;/community?page={pageNo} 에 요청 시, 다음과 같은 응답 객체 반환해요.&#10;&#10;{&#10;  &quot;posts&quot;: [기존 게시글 응답 객체],  // 기본 값으로 10개이며, 해당 페이지의 게시글 개수가 10개 미만이면, 해당하는 개수만큼 들어있어요.&#10;  &quot;totalPageCount&quot;: 3,  // 총 페이지 개수 &#10;  &quot;totalPostCount&quot;: 23  // 총 게시글 개수&#10;}&#10;&#10;- pageNo의 기본값은 0이에요. 만약 최신 게시글 10개만 불러오려면, /community 경로로 요청하면 돼요. 즉, 이 경우에는 물음표 뒤 생략이 가능해요.&#10;&#10;## 예제&#10;&#10;총 23개의 게시글이 존재하면, 총 3개의 페이지로 구분할 수 있어요.&#10;&#10;- 1번째부터 10번째 게시글&#10;- 11번째부터 20번째 게시글&#10;- 21번째부터 23번째 게시글&#10;&#10;따라서, 만약 11번째부터 20번째 게시글을 불러오고 싶으면, api 경로의 pageNo에 1를 넣어줘요. (/community?page=1)">
+      <option name="closed" value="true" />
+      <created>1706186960797</created>
+      <option name="number" value="00031" />
+      <option name="presentableId" value="LOCAL-00031" />
+      <option name="project" value="LOCAL" />
+      <updated>1706186960797</updated>
+    </task>
+    <option name="localTasksCounter" value="32" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -575,7 +583,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="[HC-68] 특정 게시글 정보 조회 기능 구현&#10;&#10;- Post 패키지명에 따라서 이름 변경" />
     <MESSAGE value="[HC-68] 댓글 패키지 생성" />
     <MESSAGE value="[HC-68] 댓글 조회 기능 구현" />
     <MESSAGE value="[HC-68] 게시글 조회 응답 객체에 댓글 개수 추가" />
@@ -600,7 +607,8 @@
     <MESSAGE value="[HC-129] 대댓글 삭제 기능 구현&#10;&#10;부모 댓글이 삭제되지 않은 상태에서 대댓글을 삭제하면 대댓글만 삭제돼요.&#10;&#10;만약 대댓글이 달린 부모 댓글을 삭제하면, 부모 댓글의 softRemoved 필드값이 true가 되며, 달려있는 대댓글이 모두 삭제되기 전까지 부모 댓글은 삭제되지 않아요. 하지만 댓글 내용을 알 수 없어요.&#10;&#10;#### 게시글 조회&#10;&#10;게시글 조회 시, 대댓글 개수도 총 댓글 개수에 포함돼요." />
     <MESSAGE value="[HC-137] 게시글 수정 여부 반환 &#10;&#10;게시글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요." />
     <MESSAGE value="[HC-137] 댓글 및 답글 수정 여부 반환 &#10;&#10;댓글 및 답글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요." />
-    <option name="LAST_COMMIT_MESSAGE" value="[HC-137] 댓글 및 답글 수정 여부 반환 &#10;&#10;댓글 및 답글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요." />
+    <MESSAGE value="[HC-140] 게시글 페이지네이션 기능 구현 &#10;&#10;## api에 요청 시, 응답 객체 변경 (프론트에서 반영해줘야 함!!!)&#10;&#10;/community?page={pageNo} 에 요청 시, 다음과 같은 응답 객체 반환해요.&#10;&#10;{&#10;  &quot;posts&quot;: [기존 게시글 응답 객체],  // 기본 값으로 10개이며, 해당 페이지의 게시글 개수가 10개 미만이면, 해당하는 개수만큼 들어있어요.&#10;  &quot;totalPageCount&quot;: 3,  // 총 페이지 개수 &#10;  &quot;totalPostCount&quot;: 23  // 총 게시글 개수&#10;}&#10;&#10;- pageNo의 기본값은 0이에요. 만약 최신 게시글 10개만 불러오려면, /community 경로로 요청하면 돼요. 즉, 이 경우에는 물음표 뒤 생략이 가능해요.&#10;&#10;## 예제&#10;&#10;총 23개의 게시글이 존재하면, 총 3개의 페이지로 구분할 수 있어요.&#10;&#10;- 1번째부터 10번째 게시글&#10;- 11번째부터 20번째 게시글&#10;- 21번째부터 23번째 게시글&#10;&#10;따라서, 만약 11번째부터 20번째 게시글을 불러오고 싶으면, api 경로의 pageNo에 1를 넣어줘요. (/community?page=1)" />
+    <option name="LAST_COMMIT_MESSAGE" value="[HC-140] 게시글 페이지네이션 기능 구현 &#10;&#10;## api에 요청 시, 응답 객체 변경 (프론트에서 반영해줘야 함!!!)&#10;&#10;/community?page={pageNo} 에 요청 시, 다음과 같은 응답 객체 반환해요.&#10;&#10;{&#10;  &quot;posts&quot;: [기존 게시글 응답 객체],  // 기본 값으로 10개이며, 해당 페이지의 게시글 개수가 10개 미만이면, 해당하는 개수만큼 들어있어요.&#10;  &quot;totalPageCount&quot;: 3,  // 총 페이지 개수 &#10;  &quot;totalPostCount&quot;: 23  // 총 게시글 개수&#10;}&#10;&#10;- pageNo의 기본값은 0이에요. 만약 최신 게시글 10개만 불러오려면, /community 경로로 요청하면 돼요. 즉, 이 경우에는 물음표 뒤 생략이 가능해요.&#10;&#10;## 예제&#10;&#10;총 23개의 게시글이 존재하면, 총 3개의 페이지로 구분할 수 있어요.&#10;&#10;- 1번째부터 10번째 게시글&#10;- 11번째부터 20번째 게시글&#10;- 21번째부터 23번째 게시글&#10;&#10;따라서, 만약 11번째부터 20번째 게시글을 불러오고 싶으면, api 경로의 pageNo에 1를 넣어줘요. (/community?page=1)" />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,13 +4,16 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="5b42d689-d7d0-4ba2-a267-4384bfcc2fe3" name="Changes" comment="[HC-137] 게시글 수정 여부 반환 &#10;&#10;게시글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요.">
+    <list default="true" id="5b42d689-d7d0-4ba2-a267-4384bfcc2fe3" name="Changes" comment="[HC-137] 댓글 및 답글 수정 여부 반환 &#10;&#10;댓글 및 답글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요.">
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/dto/PostsResponse.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/domain/Comment.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/domain/Comment.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/dto/CommentResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/dto/CommentResponse.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/dto/ReplyResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/dto/ReplyResponse.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/config/SecurityConfig.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/config/SecurityConfig.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/service/CommentServiceTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/controller/PostController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/controller/PostController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/service/PostService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/service/PostService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -109,11 +112,13 @@
     "Gradle.PostControllerTest.findAllPosts.executor": "Run",
     "Gradle.PostControllerTest.findPost.executor": "Run",
     "Gradle.PostControllerTest.findPost_exception_invalidId.executor": "Run",
+    "Gradle.PostControllerTest.findPosts.executor": "Run",
     "Gradle.PostControllerTest.likePost_up.executor": "Run",
     "Gradle.PostControllerTest.updatePost.executor": "Run",
     "Gradle.PostServiceTest.addPost_exception_invalid_category.executor": "Run",
     "Gradle.PostServiceTest.deletePost.executor": "Run",
     "Gradle.PostServiceTest.executor": "Run",
+    "Gradle.PostServiceTest.findAllPosts_login.executor": "Run",
     "Gradle.PostServiceTest.likePost.executor": "Run",
     "Gradle.PostServiceTest.likePost_down.executor": "Run",
     "Gradle.PostServiceTest.likePost_up.executor": "Debug",
@@ -133,7 +138,7 @@
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
     "create.test.in.the.same.root": "true",
-    "git-widget-placeholder": "HC-137-community-update",
+    "git-widget-placeholder": "HC-140-pagination",
     "ignore.virus.scanning.warn.message": "true",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/pagh/Desktop/honeycourses-backend-spring/build.gradle",
@@ -170,79 +175,7 @@
       <recent name="org.wooriverygood.api.post.controller" />
     </key>
   </component>
-  <component name="RunManager" selected="Gradle.CommentServiceTest.updateComment">
-    <configuration name="CommentControllerTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
-      <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" value="" />
-        <option name="taskDescriptions">
-          <list />
-        </option>
-        <option name="taskNames">
-          <list>
-            <option value=":test" />
-            <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.comment.controller.CommentControllerTest&quot;" />
-          </list>
-        </option>
-        <option name="vmOptions" />
-      </ExternalSystemSettings>
-      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
-      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-      <DebugAllEnabled>false</DebugAllEnabled>
-      <RunAsTest>true</RunAsTest>
-      <method v="2" />
-    </configuration>
-    <configuration name="CommentServiceTest.deletePrentAndReply" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
-      <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" value="" />
-        <option name="taskDescriptions">
-          <list />
-        </option>
-        <option name="taskNames">
-          <list>
-            <option value=":test" />
-            <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest.deletePrentAndReply&quot;" />
-          </list>
-        </option>
-        <option name="vmOptions" />
-      </ExternalSystemSettings>
-      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
-      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-      <DebugAllEnabled>false</DebugAllEnabled>
-      <RunAsTest>true</RunAsTest>
-      <method v="2" />
-    </configuration>
-    <configuration name="CommentServiceTest.deleteReply_keep_parent" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
-      <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" value="" />
-        <option name="taskDescriptions">
-          <list />
-        </option>
-        <option name="taskNames">
-          <list>
-            <option value=":test" />
-            <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest.deleteReply_keep_parent&quot;" />
-          </list>
-        </option>
-        <option name="vmOptions" />
-      </ExternalSystemSettings>
-      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
-      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-      <DebugAllEnabled>false</DebugAllEnabled>
-      <RunAsTest>true</RunAsTest>
-      <method v="2" />
-    </configuration>
+  <component name="RunManager" selected="Gradle.PostServiceTest.findAllPosts_login">
     <configuration name="CommentServiceTest.updateComment" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
@@ -257,6 +190,54 @@
             <option value=":test" />
             <option value="--tests" />
             <option value="&quot;org.wooriverygood.api.comment.service.CommentServiceTest.updateComment&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <configuration name="PostControllerTest.findPosts" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;org.wooriverygood.api.post.controller.PostControllerTest.findPosts&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <configuration name="PostServiceTest.findAllPosts_login" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;org.wooriverygood.api.post.service.PostServiceTest.findAllPosts_login&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -291,13 +272,26 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
+    <configuration name="HoneycoursesBackend" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" temporary="true" nameIsGenerated="true">
+      <module name="honeycourses-backend-spring.main" />
+      <option name="SPRING_BOOT_MAIN_CLASS" value="org.wooriverygood.api.HoneycoursesBackend" />
+      <extension name="coverage">
+        <pattern>
+          <option name="PATTERN" value="org.wooriverygood.api.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Gradle.PostServiceTest.findAllPosts_login" />
+        <item itemvalue="Gradle.PostControllerTest.findPosts" />
+        <item itemvalue="Spring Boot.HoneycoursesBackend" />
         <item itemvalue="Gradle.CommentServiceTest.updateComment" />
         <item itemvalue="Gradle.PostServiceTest.updatePost" />
-        <item itemvalue="Gradle.CommentControllerTest" />
-        <item itemvalue="Gradle.CommentServiceTest.deletePrentAndReply" />
-        <item itemvalue="Gradle.CommentServiceTest.deleteReply_keep_parent" />
       </list>
     </recent_temporary>
   </component>
@@ -321,7 +315,7 @@
       <workItem from="1705241248366" duration="871000" />
       <workItem from="1705301106038" duration="464000" />
       <workItem from="1705302176845" duration="9723000" />
-      <workItem from="1706178673625" duration="1246000" />
+      <workItem from="1706178673625" duration="7475000" />
     </task>
     <task id="LOCAL-00001" summary="project init">
       <option name="closed" value="true" />
@@ -555,7 +549,15 @@
       <option name="project" value="LOCAL" />
       <updated>1706179523887</updated>
     </task>
-    <option name="localTasksCounter" value="30" />
+    <task id="LOCAL-00030" summary="[HC-137] 댓글 및 답글 수정 여부 반환 &#10;&#10;댓글 및 답글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요.">
+      <option name="closed" value="true" />
+      <created>1706179972211</created>
+      <option name="number" value="00030" />
+      <option name="presentableId" value="LOCAL-00030" />
+      <option name="project" value="LOCAL" />
+      <updated>1706179972211</updated>
+    </task>
+    <option name="localTasksCounter" value="31" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -573,7 +575,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="[HC-68] 모든 게시글 불러오기 기능 구현" />
     <MESSAGE value="[HC-68] 특정 게시글 정보 조회 기능 구현&#10;&#10;- Post 패키지명에 따라서 이름 변경" />
     <MESSAGE value="[HC-68] 댓글 패키지 생성" />
     <MESSAGE value="[HC-68] 댓글 조회 기능 구현" />
@@ -598,7 +599,8 @@
     <MESSAGE value="[HC-129] 대댓글 작성 기능 구현&#10;&#10;댓글과 대댓글 모두 Comment 객체로 처리했어요.&#10;&#10;- Comment 클래스에 parent, children 필드 추가&#10;&#10;일반 댓글은 parent 필드 값이 null 이며, childrent 필드에는 대댓글 객체들이 들어가요.&#10;&#10;따라서 대댓글은 모두 같은 부모 댓글을 바라보며, 대댓글의 대댓글은 불가능해요." />
     <MESSAGE value="[HC-129] 대댓글 삭제 기능 구현&#10;&#10;부모 댓글이 삭제되지 않은 상태에서 대댓글을 삭제하면 대댓글만 삭제돼요.&#10;&#10;만약 대댓글이 달린 부모 댓글을 삭제하면, 부모 댓글의 softRemoved 필드값이 true가 되며, 달려있는 대댓글이 모두 삭제되기 전까지 부모 댓글은 삭제되지 않아요. 하지만 댓글 내용을 알 수 없어요.&#10;&#10;#### 게시글 조회&#10;&#10;게시글 조회 시, 대댓글 개수도 총 댓글 개수에 포함돼요." />
     <MESSAGE value="[HC-137] 게시글 수정 여부 반환 &#10;&#10;게시글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요." />
-    <option name="LAST_COMMIT_MESSAGE" value="[HC-137] 게시글 수정 여부 반환 &#10;&#10;게시글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요." />
+    <MESSAGE value="[HC-137] 댓글 및 답글 수정 여부 반환 &#10;&#10;댓글 및 답글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요." />
+    <option name="LAST_COMMIT_MESSAGE" value="[HC-137] 댓글 및 답글 수정 여부 반환 &#10;&#10;댓글 및 답글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요." />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
+++ b/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
@@ -56,8 +56,10 @@ public class Comment {
     private LocalDateTime createdAt;
 
     @Column(name = "soft_removed")
+    @ColumnDefault("false")
     private boolean softRemoved;
 
+    @ColumnDefault("false")
     private boolean updated;
 
     @Builder

--- a/src/main/java/org/wooriverygood/api/post/controller/PostController.java
+++ b/src/main/java/org/wooriverygood/api/post/controller/PostController.java
@@ -1,6 +1,8 @@
 package org.wooriverygood.api.post.controller;
 
 import jakarta.validation.Valid;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,15 +19,19 @@ public class PostController {
 
     private final PostService postService;
 
+    private final int PAGE_SIZE = 10;
+
 
     public PostController(PostService postService) {
         this.postService = postService;
     }
 
     @GetMapping
-    public ResponseEntity<List<PostResponse>> findAllPosts(@Login AuthInfo authInfo) {
-        List<PostResponse> postResponses = postService.findAllPosts(authInfo);
-        return ResponseEntity.ok(postResponses);
+    public ResponseEntity<PostsResponse> findPosts(@Login AuthInfo authInfo,
+                                                   @RequestParam(required = false, defaultValue = "0", value = "page") int pageNo) {
+        Pageable pageable = PageRequest.of(pageNo, PAGE_SIZE);
+        PostsResponse response = postService.findPosts(authInfo, pageable);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/org/wooriverygood/api/post/controller/PostController.java
+++ b/src/main/java/org/wooriverygood/api/post/controller/PostController.java
@@ -11,7 +11,6 @@ import org.wooriverygood.api.post.service.PostService;
 import org.wooriverygood.api.support.AuthInfo;
 import org.wooriverygood.api.support.Login;
 
-import java.util.List;
 
 @RestController
 @RequestMapping("/community")
@@ -49,9 +48,11 @@ public class PostController {
     }
 
     @GetMapping("/me")
-    public ResponseEntity<List<PostResponse>> findMyPosts(@Login AuthInfo authInfo) {
-        List<PostResponse> postResponses = postService.findMyPosts(authInfo);
-        return ResponseEntity.ok(postResponses);
+    public ResponseEntity<PostsResponse> findMyPosts(@Login AuthInfo authInfo,
+                                                     @RequestParam(required = false, defaultValue = "0", value = "page") int pageNo) {
+        Pageable pageable = PageRequest.of(pageNo, PAGE_SIZE);
+        PostsResponse response = postService.findMyPosts(authInfo, pageable);
+        return ResponseEntity.ok(response);
     }
 
     @PutMapping("/{id}/like")

--- a/src/main/java/org/wooriverygood/api/post/dto/PostsResponse.java
+++ b/src/main/java/org/wooriverygood/api/post/dto/PostsResponse.java
@@ -1,0 +1,25 @@
+package org.wooriverygood.api.post.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class PostsResponse {
+
+    private final List<PostResponse> posts;
+
+    private final int totalPageCount;
+
+    private final long totalPostCount;
+
+
+    @Builder
+    public PostsResponse(List<PostResponse> posts, int totalPageCount, long totalPostCount) {
+        this.posts = posts;
+        this.totalPageCount = totalPageCount;
+        this.totalPostCount = totalPostCount;
+    }
+
+}

--- a/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java
+++ b/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java
@@ -8,13 +8,12 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.transaction.annotation.Transactional;
 import org.wooriverygood.api.post.domain.Post;
 
-import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findAllByOrderByIdDesc(Pageable pageable);
 
-    List<Post> findByAuthor(String author);
+    Page<Post> findByAuthorOrderByIdDesc(String author, Pageable pageable);
 
     @Transactional
     @Modifying(clearAutomatically = true)

--- a/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java
+++ b/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java
@@ -1,5 +1,7 @@
 package org.wooriverygood.api.post.repository;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +11,8 @@ import org.wooriverygood.api.post.domain.Post;
 import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Page<Post> findAllByOrderByIdDesc(Pageable pageable);
 
     List<Post> findByAuthor(String author);
 

--- a/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java
+++ b/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -167,7 +168,7 @@ class PostControllerTest extends ControllerTest {
     @DisplayName("사용자 본인이 작성한 게시글을 불러온다.")
     void findMyPosts() {
         List<PostResponse> responses = new ArrayList<>();
-        for (int i = 1; i < 11; i++) {
+        for (int i = 1; i < 21; i++) {
             responses.add(PostResponse.builder()
                     .post_id((long) i)
                     .post_title("title")
@@ -182,13 +183,19 @@ class PostControllerTest extends ControllerTest {
                     .build());
         }
 
-        Mockito.when(postService.findMyPosts(any(AuthInfo.class)))
-                .thenReturn(responses);
+        response = PostsResponse.builder()
+                .posts(this.responses.stream().filter(it -> it.getPost_id() >= 11 && it.getPost_id() <= 20).toList())
+                .totalPostCount(20)
+                .totalPageCount(2)
+                .build();
+
+        Mockito.when(postService.findMyPosts(any(AuthInfo.class), any(PageRequest.class)))
+                .thenReturn(response);
 
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "Bearer aws-cognito-access-token")
-                .when().get("/community/me")
+                .when().get("/community/me?page=1")
                 .then().log().all()
                 .assertThat()
                 .apply(document("post/find/me/success"))

--- a/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java
+++ b/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.wooriverygood.api.advice.exception.AuthorizationException;
@@ -22,6 +23,7 @@ import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.docu
 
 class PostControllerTest extends ControllerTest {
 
+    PostsResponse response;
     List<PostResponse> responses = new ArrayList<>();
 
     AuthInfo authInfo = AuthInfo.builder()
@@ -32,7 +34,7 @@ class PostControllerTest extends ControllerTest {
 
     @BeforeEach
     void setUp() {
-        for (int i = 1; i <= 4; i++) {
+        for (int i = 1; i <= 23; i++) {
             responses.add(PostResponse.builder()
                     .post_id((long) i)
                     .post_title("title" + i)
@@ -42,22 +44,27 @@ class PostControllerTest extends ControllerTest {
                     .post_comments(10 + i)
                     .post_likes(2 + i)
                     .post_time(LocalDateTime.now())
-                    .liked(i % 3 == 0)
+                    .liked(i % 5 == 0)
                     .updated(i % 2 == 0)
                     .build());
         }
+        response = PostsResponse.builder()
+                .posts(responses.stream().filter(it -> it.getPost_id() >= 4 && it.getPost_id() < 14).toList())
+                .totalPostCount(23)
+                .totalPageCount(3)
+                .build();
     }
 
     @Test
     @DisplayName("게시글을 전부 반환한다.")
-    void findAllPosts() {
-        Mockito.when(postService.findAllPosts(any(AuthInfo.class)))
-                .thenReturn(responses);
+    void findPosts() {
+        Mockito.when(postService.findPosts(any(AuthInfo.class), any(Pageable.class)))
+                .thenReturn(response);
 
         restDocs
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .header("Authorization", "Bearer aws-cognito-access-token")
-                .when().get("/community")
+                .when().get("/community?page=1")
                 .then().log().all()
                 .assertThat()
                 .apply(document("post/find/all/success"))

--- a/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java
@@ -9,6 +9,9 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.wooriverygood.api.advice.exception.AuthorizationException;
 import org.wooriverygood.api.advice.exception.InvalidPostCategoryException;
 import org.wooriverygood.api.advice.exception.PostNotFoundException;
@@ -42,7 +45,7 @@ class PostServiceTest {
     @Mock
     private CommentRepository commentRepository;
 
-    private final int POST_COUNT = 10;
+    private final int POST_COUNT = 23;
 
     List<Post> posts = new ArrayList<>();
 
@@ -74,9 +77,9 @@ class PostServiceTest {
 
     @BeforeEach
     void setUpPosts() {
-        for (int i = 0; i < POST_COUNT; i++) {
+        for (int i = 1; i <= POST_COUNT; i++) {
             Post post = Post.builder()
-                    .id((long) (i + 1))
+                    .id((long) i)
                     .category(PostCategory.FREE)
                     .title("title" + i)
                     .content("content" + i)
@@ -89,14 +92,22 @@ class PostServiceTest {
     }
 
     @Test
-    @DisplayName("로그인 한 상황에서 모든 게시글을 불러온다.")
+    @DisplayName("로그인 한 상황에서 게시글을 불러온다.")
     void findAllPosts_login() {
-        Mockito.when(postRepository.findAll())
-                .thenReturn(posts);
+        Pageable pageable = PageRequest.of(0, 10);
 
-        List<PostResponse> responses = postService.findAllPosts(authInfo);
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), this.posts.size());
+        List<Post> posts = this.posts.subList(start, end);
+        PageImpl<Post> page = new PageImpl<>(posts, pageable, this.posts.size());
+        Mockito.when(postRepository.findAllByOrderByIdDesc(any(PageRequest.class)))
+                .thenReturn(page);
 
-        Assertions.assertThat(responses.size()).isEqualTo(POST_COUNT);
+        PostsResponse response = postService.findPosts(authInfo, pageable);
+
+        Assertions.assertThat(response.getPosts().size()).isEqualTo(10);
+        Assertions.assertThat(response.getTotalPageCount()).isEqualTo(3);
+        Assertions.assertThat(response.getTotalPostCount()).isEqualTo(POST_COUNT);
     }
 
     @Test


### PR DESCRIPTION
## api에 요청 시, 응답 객체 변경 (프론트에서 반영해줘야 함!!!)

api에 요청 시, 다음과 같은 응답 객체 반환해요.

```javascript
{
  "posts": [기존 게시글 응답 객체],  // 기본 값으로 10개이며, 해당 페이지의 게시글 개수가 10개 미만이면, 해당하는 개수만큼 들어있어요.
  "totalPageCount": 3,  // 총 페이지 개수
  "totalPostCount": 23  // 총 게시글 개수
}
```

### api 경로

경로는 다음과 같아요.

- `/community?page={pageNo}`

pageNo의 기본값은 0이에요. 따라서 최신 게시글 10개만 불러오려면, /community 경로로 요청하면 돼요. 즉, 이 경우에는 물음표 뒤 생략이 가능해요.

## 예제

총 23개의 게시글이 존재하면, 총 3개의 페이지로 구분할 수 있어요.

- 1번째 페이지: 1번째부터 10번째 게시글
- 2번째 페이지: 11번째부터 20번째 게시글
- 3번째 페이지: 21번째부터 23번째 게시글

### 1번째 페이지

만약 1번째부터 10번째 게시글을 불러오고 싶으면, api 경로는 다음과 같아요.

- `/community` 혹은 `/community?page=0`

### 2번째 페이지

만약 11번째부터 20번째 게시글을 불러오고 싶으면, api 경로의 pageNo에 1를 넣어줘서 다음과 같아요.

- `/community?page=1`

### 3번째 페이지

만약 21번째부터 23번째 게시글을 불러오고 싶으면, api 경로의 pageNo에 2를 넣어줘서 다음과 같아요.

- `/community?page=2`
