### PR TITLE
[HC-128] 강의평가 제목/내용 외 다른 내용도 수정 가능하게 변경, 수정 여부 추가

### DIFF
--- a/src/main/java/org/wooriverygood/api/review/domain/Review.java
+++ b/src/main/java/org/wooriverygood/api/review/domain/Review.java
@@ -57,8 +57,11 @@ public class Review {
     @OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ReviewLike> reviewLikes;
 
+    @ColumnDefault("false")
+    private boolean updated;
+
     @Builder
-    public Review(Long id, Courses course, String reviewContent, String reviewTitle, String instructorName, String takenSemyr, String grade, String authorEmail, List<ReviewLike> reviewLikes) {
+    public Review(Long id, Courses course, String reviewContent, String reviewTitle, String instructorName, String takenSemyr, String grade, String authorEmail, List<ReviewLike> reviewLikes, boolean updated) {
         this.id = id;
         this.course = course;
         this.reviewContent = reviewContent;
@@ -68,6 +71,7 @@ public class Review {
         this.grade = grade;
         this.authorEmail = authorEmail;
         this.reviewLikes = reviewLikes;
+        this.updated = updated;
     }
 
     public boolean isSameAuthor(String author) {
@@ -87,12 +91,13 @@ public class Review {
         reviewLike.delete();
     }
 
-    public void updateTitle(String title) {
+    public void updateReview(String title, String instructorName, String takenSemyr, String content, String grade) {
         this.reviewTitle = title;
-    }
-
-    public void updateContent(String content) {
         this.reviewContent = content;
+        this.instructorName = instructorName;
+        this.takenSemyr = takenSemyr;
+        this.grade = grade;
+        updated = true;
     }
 
 

--- a/src/main/java/org/wooriverygood/api/review/dto/ReviewResponse.java
+++ b/src/main/java/org/wooriverygood/api/review/dto/ReviewResponse.java
@@ -19,9 +19,10 @@ public class ReviewResponse {
     private final LocalDateTime review_time;
     private final boolean isMine;
     private final boolean liked;
+    private final boolean updated;
 
     @Builder
-    public ReviewResponse(Long review_id, Long course_id, String review_content, String review_title, String instructor_name, String taken_semyr, String grade, int like_count, LocalDateTime review_time, boolean isMine, boolean liked) {
+    public ReviewResponse(Long review_id, Long course_id, String review_content, String review_title, String instructor_name, String taken_semyr, String grade, int like_count, LocalDateTime review_time, boolean isMine, boolean liked, boolean updated) {
         this.review_id = review_id;
         this.course_id = course_id;
         this.review_content = review_content;
@@ -33,6 +34,7 @@ public class ReviewResponse {
         this.review_time = review_time;
         this.isMine = isMine;
         this.liked = liked;
+        this.updated = updated;
     }
 
     public static ReviewResponse from(Review review, boolean isMine, boolean liked) {
@@ -48,6 +50,7 @@ public class ReviewResponse {
                 .review_time(review.getCreatedAt())
                 .isMine(isMine)
                 .liked(liked)
+                .updated(review.isUpdated())
                 .build();
     }
 }

--- a/src/main/java/org/wooriverygood/api/review/dto/ReviewUpdateRequest.java
+++ b/src/main/java/org/wooriverygood/api/review/dto/ReviewUpdateRequest.java
@@ -10,12 +10,17 @@ import lombok.NoArgsConstructor;
 public class ReviewUpdateRequest {
     @NotBlank(message = "제목이 없습니다.")
     private String review_title;
-
+    private String instructor_name;
+    private String taken_semyr;
     private String review_content;
+    private String grade;
 
     @Builder
-    public ReviewUpdateRequest(String review_title, String review_content) {
+    public ReviewUpdateRequest(String review_title, String instructor_name, String taken_semyr, String review_content, String grade) {
         this.review_title = review_title;
+        this.instructor_name = instructor_name;
+        this.taken_semyr = taken_semyr;
         this.review_content = review_content;
+        this.grade = grade;
     }
 }

--- a/src/main/java/org/wooriverygood/api/review/service/ReviewService.java
+++ b/src/main/java/org/wooriverygood/api/review/service/ReviewService.java
@@ -123,8 +123,7 @@ public class ReviewService {
                 .orElseThrow(ReviewNotFoundException::new);
         review.validateAuthor(authInfo.getUsername());
 
-        review.updateTitle(reviewUpdateRequest.getReview_title());
-        review.updateContent(reviewUpdateRequest.getReview_content());
+        review.updateReview(reviewUpdateRequest.getReview_title(), reviewUpdateRequest.getInstructor_name(), reviewUpdateRequest.getTaken_semyr(), reviewUpdateRequest.getReview_content(), reviewUpdateRequest.getGrade());
 
         return ReviewUpdateResponse.builder()
                 .review_id(review.getId())

--- a/src/test/java/org/wooriverygood/api/review/controller/ReviewControllerTest.java
+++ b/src/test/java/org/wooriverygood/api/review/controller/ReviewControllerTest.java
@@ -49,6 +49,7 @@ public class ReviewControllerTest extends ControllerTest {
                     .grade("60")
                     .review_time(LocalDateTime.now())
                     .isMine(false)
+                    .updated(false)
                     .build());
         }
     }
@@ -137,6 +138,7 @@ public class ReviewControllerTest extends ControllerTest {
                     .grade("60")
                     .review_time(LocalDateTime.now())
                     .isMine(true)
+                    .updated(false)
                     .build());
         }
 
@@ -159,6 +161,9 @@ public class ReviewControllerTest extends ControllerTest {
         ReviewUpdateRequest request = ReviewUpdateRequest.builder()
                 .review_title("new title")
                 .review_content("new content")
+                .instructor_name("jiaoshou")
+                .taken_semyr("18-19")
+                .grade("100")
                 .build();
 
         Mockito.when(reviewService.updateReview(any(Long.class), any(ReviewUpdateRequest.class), any(AuthInfo.class)))

--- a/src/test/java/org/wooriverygood/api/review/service/ReviewServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/review/service/ReviewServiceTest.java
@@ -70,6 +70,7 @@ public class ReviewServiceTest {
                     .grade("60")
                     .authorEmail("author" + i)
                     .reviewLikes(new ArrayList<>())
+                    .updated(false)
                     .build();
             reviews.add(review);
         }
@@ -85,6 +86,7 @@ public class ReviewServiceTest {
             .grade("100")
             .authorEmail(authInfo.getUsername())
             .reviewLikes(new ArrayList<>())
+            .updated(false)
             .build();
 
     Review noAuthReview = Review.builder()
@@ -97,6 +99,7 @@ public class ReviewServiceTest {
             .grade("100")
             .authorEmail("somerandom-username")
             .reviewLikes(new ArrayList<>())
+            .updated(false)
             .build();
 
     @Test
@@ -191,6 +194,9 @@ public class ReviewServiceTest {
         ReviewUpdateRequest request = ReviewUpdateRequest.builder()
                 .review_title("new title")
                 .review_content("new content")
+                .instructor_name("jiaoshou")
+                .taken_semyr("18-19")
+                .grade("100")
                 .build();
 
         Mockito.when(reviewRepository.findById(any(Long.class)))
@@ -199,6 +205,7 @@ public class ReviewServiceTest {
         ReviewUpdateResponse response = reviewService.updateReview(singleReview.getId(), request, authInfo);
 
         Assertions.assertThat(response.getReview_id()).isEqualTo(singleReview.getId());
+        Assertions.assertThat(singleReview.isUpdated()).isEqualTo(true);
     }
 
     @Test


### PR DESCRIPTION
- 강의평가는 본래 제목/내용만 수정 가능했으나, 제목/교수명/수강학기/내용/성적 모두 수정 가능하게 변경
- 커뮤니티 글/댓글처럼 updated 필드 추가해 강의평가도 수정 여부 반환하도록 추가