### PR TITLE
[HC-130] 강의목록 반환시 리뷰 갯수 반환하도록 추가

### DIFF
--- a/src/main/java/org/wooriverygood/api/course/domain/Courses.java
+++ b/src/main/java/org/wooriverygood/api/course/domain/Courses.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -30,14 +31,19 @@ public class Courses {
     @Column(name = "kaikeYuanxi", nullable = false)
     private String kaikeYuanxi;
 
+    @Column(name = "review_count", nullable = false)
+    @ColumnDefault("0")
+    private int reviewCount;
+
     @Builder
-    public Courses(Long id, String course_name, String course_category, int course_credit, int isYouguan, String kaikeYuanxi) {
+    public Courses(Long id, String course_name, String course_category, int course_credit, int isYouguan, String kaikeYuanxi, int reviewCount) {
         this.id = id;
         this.course_name = course_name;
         this.course_category = course_category;
         this.course_credit = course_credit;
         this.isYouguan = isYouguan;
         this.kaikeYuanxi = kaikeYuanxi;
+        this.reviewCount = reviewCount;
     }
 
 

--- a/src/main/java/org/wooriverygood/api/course/dto/CourseResponse.java
+++ b/src/main/java/org/wooriverygood/api/course/dto/CourseResponse.java
@@ -12,15 +12,17 @@ public class CourseResponse {
     private final String course_name;
     private final int isYouguan;
     private final String kaikeYuanxi;
+    private final int reviewCount;
 
     @Builder
-    public CourseResponse(Long course_id, String course_category, int course_credit, String course_name, int isYouguan, String kaikeYuanxi) {
+    public CourseResponse(Long course_id, String course_category, int course_credit, String course_name, int isYouguan, String kaikeYuanxi, int reviewCount) {
         this.course_id = course_id;
         this.course_category = course_category;
         this.course_credit = course_credit;
         this.course_name = course_name;
         this.isYouguan = isYouguan;
         this.kaikeYuanxi = kaikeYuanxi;
+        this.reviewCount = reviewCount;
     }
 
     public static CourseResponse from(Courses course) {
@@ -31,6 +33,7 @@ public class CourseResponse {
                 .course_name(course.getCourse_name())
                 .isYouguan(course.getIsYouguan())
                 .kaikeYuanxi(course.getKaikeYuanxi())
+                .reviewCount(course.getReviewCount())
                 .build();
     }
 }

--- a/src/main/java/org/wooriverygood/api/review/repository/ReviewRepository.java
+++ b/src/main/java/org/wooriverygood/api/review/repository/ReviewRepository.java
@@ -21,4 +21,14 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Modifying(clearAutomatically = true)
     @Query(value = "UPDATE reviews SET like_count = like_count - 1 WHERE review_id = :reviewId", nativeQuery = true)
     void decreaseLikeCount(Long reviewId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE courses SET review_count = review_count + 1 WHERE course_id = :courseId", nativeQuery = true)
+    void increaseReviewCount(Long courseId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE courses SET review_count = review_count - 1 WHERE course_id = :courseId", nativeQuery = true)
+    void decreaseReviewCount(Long courseId);
 }

--- a/src/main/java/org/wooriverygood/api/review/service/ReviewService.java
+++ b/src/main/java/org/wooriverygood/api/review/service/ReviewService.java
@@ -54,6 +54,7 @@ public class ReviewService {
                 .authorEmail(authInfo.getUsername())
                 .build();
         Review saved = reviewRepository.save(review);
+        reviewRepository.increaseReviewCount(review.getCourse().getId());
         return createResponse(saved);
     }
 
@@ -138,6 +139,7 @@ public class ReviewService {
 
         reviewLikeRepository.deleteAllByReview(review);
         reviewRepository.delete(review);
+        reviewRepository.decreaseReviewCount(review.getCourse().getId());
 
         return ReviewDeleteResponse.builder()
                 .review_id(reviewId)

--- a/src/test/java/org/wooriverygood/api/course/controller/CourseControllerTest.java
+++ b/src/test/java/org/wooriverygood/api/course/controller/CourseControllerTest.java
@@ -30,6 +30,7 @@ public class CourseControllerTest extends ControllerTest {
                     .course_name("Gaoshu"+i)
                     .isYouguan(0)
                     .kaikeYuanxi("Xinke")
+                    .reviewCount(0)
                     .build());
         }
     }

--- a/src/test/java/org/wooriverygood/api/course/service/CourseServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/course/service/CourseServiceTest.java
@@ -49,6 +49,7 @@ public class CourseServiceTest {
                     .course_credit(5)
                     .isYouguan(0)
                     .kaikeYuanxi("Xinke")
+                    .reviewCount(0)
                     .build());
         }
     }
@@ -60,6 +61,7 @@ public class CourseServiceTest {
             .course_credit(5)
             .isYouguan(0)
             .kaikeYuanxi("Xinke")
+            .reviewCount(0)
             .build();
 
 
@@ -93,6 +95,7 @@ public class CourseServiceTest {
                         .course_credit(newCourseRequest.getCourse_credit())
                         .kaikeYuanxi(newCourseRequest.getKaikeYuanxi())
                         .isYouguan(newCourseRequest.getIsYouguan())
+                        .reviewCount(0)
                         .build());
 
         NewCourseResponse response = courseService.addCourse(newCourseRequest);


### PR DESCRIPTION
이제부터 강의목록 반환 시, `review_count` 가 같이 반환되어 해당 강의의 리뷰 갯수를 나타냄.

리뷰가 추가/삭제될때 해당 칼럼이 +1/-1 되도록 로직도 수정 완료.