### PR TITLE
[HC-150] 존재하지 않는 강의의 리뷰 요청시 404 반환하도록 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -27,6 +27,9 @@ operation::course/get/name/success[snippets='http-request,http-response']
 ==== 성공
 operation::reviews/find/success[snippets='http-request,http-response']
 
+==== 실패 (존재하지 않는 수업)
+operation::reviews/find/fail[snippets='http-request,http-response']
+
 === 특정 강의의 리뷰 작성하기 (POST /courses/{id}/reviews)
 ==== 성공
 operation::reviews/create/success[snippets='http-request,http-response']

--- a/src/main/java/org/wooriverygood/api/review/service/ReviewService.java
+++ b/src/main/java/org/wooriverygood/api/review/service/ReviewService.java
@@ -28,6 +28,8 @@ public class ReviewService {
     private final ReviewLikeRepository reviewLikeRepository;
 
     public List<ReviewResponse> findAllReviewsByCourseId(Long courseId, AuthInfo authInfo) {
+        Courses course = courseRepository.findById(courseId)
+                .orElseThrow(CourseNotFoundException::new);
         List<Review> reviews = reviewRepository.findAllByCourseId(courseId);
 
         if(authInfo.getUsername() == null) {

--- a/src/test/java/org/wooriverygood/api/review/controller/ReviewControllerTest.java
+++ b/src/test/java/org/wooriverygood/api/review/controller/ReviewControllerTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mockito;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.wooriverygood.api.advice.exception.AuthorizationException;
+import org.wooriverygood.api.advice.exception.CourseNotFoundException;
 import org.wooriverygood.api.course.domain.Courses;
 import org.wooriverygood.api.review.dto.*;
 import org.wooriverygood.api.support.AuthInfo;
@@ -67,6 +68,22 @@ public class ReviewControllerTest extends ControllerTest {
                 .then().log().all()
                 .apply(document("reviews/find/success"))
                 .statusCode(HttpStatus.OK.value());
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 수업의 리뷰를 조회하면 404를 반환한다.")
+    void findReviews_exception_invalidId() {
+        Mockito.when(reviewService.findAllReviewsByCourseId(any(Long.class), any(AuthInfo.class)))
+                .thenThrow(new CourseNotFoundException());
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer aws-cognito-access-token")
+                .when().get("/courses/1/reviews")
+                .then().log().all()
+                .assertThat()
+                .apply(document("reviews/find/fail"))
+                .statusCode(HttpStatus.NOT_FOUND.value());
     }
 
     @Test


### PR DESCRIPTION
- findAllReviewsByCourseId를 실행 시, 먼저 해당 수업이 존재하는지 확인하고, 존재하지 않을경우 404 에러를 반환하도록 수정.