### PR TITLE
[HC-157] 게시글 및 댓글 신고 기능 구현

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,14 +5,23 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="5b42d689-d7d0-4ba2-a267-4384bfcc2fe3" name="Changes" comment="[HC-140] 게시글 페이지네이션 기능 구현 &#10;&#10;## api에 요청 시, 응답 객체 변경 (프론트에서 반영해줘야 함!!!)&#10;&#10;/community?page={pageNo} 에 요청 시, 다음과 같은 응답 객체 반환해요.&#10;&#10;{&#10;  &quot;posts&quot;: [기존 게시글 응답 객체],  // 기본 값으로 10개이며, 해당 페이지의 게시글 개수가 10개 미만이면, 해당하는 개수만큼 들어있어요.&#10;  &quot;totalPageCount&quot;: 3,  // 총 페이지 개수 &#10;  &quot;totalPostCount&quot;: 23  // 총 게시글 개수&#10;}&#10;&#10;- pageNo의 기본값은 0이에요. 만약 최신 게시글 10개만 불러오려면, /community 경로로 요청하면 돼요. 즉, 이 경우에는 물음표 뒤 생략이 가능해요.&#10;&#10;## 예제&#10;&#10;총 23개의 게시글이 존재하면, 총 3개의 페이지로 구분할 수 있어요.&#10;&#10;- 1번째부터 10번째 게시글&#10;- 11번째부터 20번째 게시글&#10;- 21번째부터 23번째 게시글&#10;&#10;따라서, 만약 11번째부터 20번째 게시글을 불러오고 싶으면, api 경로의 pageNo에 1를 넣어줘요. (/community?page=1)">
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/advice/exception/DuplicatedPostReportException.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/controller/ReportController.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/domain/PostReport.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/dto/ReportRequest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/repository/CommentReportRepository.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/repository/PostReportRepository.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/service/ReportService.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/report/controller/ReportControllerTest.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/report/service/ReportServiceTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/docs/asciidoc/index.adoc" beforeDir="false" afterPath="$PROJECT_DIR$/src/docs/asciidoc/index.adoc" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/config/SecurityConfig.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/config/SecurityConfig.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/controller/PostController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/controller/PostController.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/domain/PostCategory.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/domain/PostCategory.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/advice/exception/ReplyDepthException.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/advice/exception/ReplyDepthException.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/domain/Post.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/domain/Post.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/dto/PostResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/dto/PostResponse.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/service/PostService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/service/PostService.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/controller/PostControllerTest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/post/service/PostServiceTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/util/ControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/util/ControllerTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/util/ResponseFixture.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/util/ResponseFixture.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -126,6 +135,11 @@
     "Gradle.PostServiceTest.likePost_down.executor": "Run",
     "Gradle.PostServiceTest.likePost_up.executor": "Debug",
     "Gradle.PostServiceTest.updatePost.executor": "Run",
+    "Gradle.ReportControllerTest.reportPost (1).executor": "Run",
+    "Gradle.ReportControllerTest.reportPost.executor": "Run",
+    "Gradle.ReportServiceTest.reportPost.executor": "Run",
+    "Gradle.ReportServiceTest.reportPost_exception_duplicated.executor": "Run",
+    "Gradle.ReportServiceTest.reportPost_exception_invalidId.executor": "Run",
     "Notification.DisplayName-DoNotAsk-Lombok plugin": "Lombok integration problem",
     "Notification.DoNotAsk-Lombok plugin": "true",
     "RequestMappingsPanelOrder0": "0",
@@ -142,7 +156,7 @@
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
     "create.test.in.the.same.root": "true",
     "extract.method.default.visibility": "private",
-    "git-widget-placeholder": "HC-142-post-category",
+    "git-widget-placeholder": "HC-157-community-report",
     "ignore.virus.scanning.warn.message": "true",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/pagh/Desktop/honeycourses-backend-spring/build.gradle",
@@ -165,22 +179,23 @@
 }]]></component>
   <component name="RecentsManager">
     <key name="CreateClassDialog.RecentsKey">
+      <recent name="report.controller" />
       <recent name="org.wooriverygood.api.comment.dto" />
       <recent name="org.wooriverygood.api.advice.exception" />
       <recent name="org.wooriverygood.api.exception" />
       <recent name="org.wooriverygood.api.post.dto" />
-      <recent name="org.wooriverygood.api.post.repository" />
     </key>
     <key name="CreateTestDialog.Recents.Supers">
       <recent name="" />
     </key>
     <key name="CreateTestDialog.RecentsKey">
+      <recent name="org.wooriverygood.api.report.service" />
       <recent name="org.wooriverygood.api.comment.controller" />
       <recent name="org.wooriverygood.api.post.controller" />
     </key>
   </component>
-  <component name="RunManager" selected="Spring Boot.HoneycoursesBackend">
-    <configuration name="PostControllerTest.findMyPosts" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+  <component name="RunManager" selected="Gradle.ReportServiceTest.reportPost_exception_duplicated">
+    <configuration name="ReportControllerTest.reportPost (1)" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -193,7 +208,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.post.controller.PostControllerTest.findMyPosts&quot;" />
+            <option value="&quot;org.wooriverygood.api.report.controller.ReportControllerTest.reportPost&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -204,7 +219,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="PostControllerTest.findPostsByCategory" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="ReportControllerTest.reportPost" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -217,7 +232,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.post.controller.PostControllerTest.findPostsByCategory&quot;" />
+            <option value="&quot;report.controller.ReportControllerTest.reportPost&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -228,7 +243,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="PostServiceTest.findMyPosts" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="ReportServiceTest.reportPost" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -241,7 +256,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.post.service.PostServiceTest.findMyPosts&quot;" />
+            <option value="&quot;org.wooriverygood.api.report.service.ReportServiceTest.reportPost&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -252,7 +267,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="PostServiceTest.findPosts_category_free" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="ReportServiceTest.reportPost_exception_duplicated" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -265,7 +280,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.post.service.PostServiceTest.findPosts_category_free&quot;" />
+            <option value="&quot;org.wooriverygood.api.report.service.ReportServiceTest.reportPost_exception_duplicated&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -276,26 +291,37 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="HoneycoursesBackend" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" temporary="true" nameIsGenerated="true">
-      <module name="honeycourses-backend-spring.main" />
-      <option name="SPRING_BOOT_MAIN_CLASS" value="org.wooriverygood.api.HoneycoursesBackend" />
-      <extension name="coverage">
-        <pattern>
-          <option name="PATTERN" value="org.wooriverygood.api.*" />
-          <option name="ENABLED" value="true" />
-        </pattern>
-      </extension>
-      <method v="2">
-        <option name="Make" enabled="true" />
-      </method>
+    <configuration name="ReportServiceTest.reportPost_exception_invalidId" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;org.wooriverygood.api.report.service.ReportServiceTest.reportPost_exception_invalidId&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Spring Boot.HoneycoursesBackend" />
-        <item itemvalue="Gradle.PostServiceTest.findPosts_category_free" />
-        <item itemvalue="Gradle.PostControllerTest.findPostsByCategory" />
-        <item itemvalue="Gradle.PostServiceTest.findMyPosts" />
-        <item itemvalue="Gradle.PostControllerTest.findMyPosts" />
+        <item itemvalue="Gradle.ReportServiceTest.reportPost_exception_duplicated" />
+        <item itemvalue="Gradle.ReportServiceTest.reportPost_exception_invalidId" />
+        <item itemvalue="Gradle.ReportServiceTest.reportPost" />
+        <item itemvalue="Gradle.ReportControllerTest.reportPost (1)" />
+        <item itemvalue="Gradle.ReportControllerTest.reportPost" />
       </list>
     </recent_temporary>
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,24 +4,21 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="5b42d689-d7d0-4ba2-a267-4384bfcc2fe3" name="Changes" comment="[HC-140] 게시글 페이지네이션 기능 구현 &#10;&#10;## api에 요청 시, 응답 객체 변경 (프론트에서 반영해줘야 함!!!)&#10;&#10;/community?page={pageNo} 에 요청 시, 다음과 같은 응답 객체 반환해요.&#10;&#10;{&#10;  &quot;posts&quot;: [기존 게시글 응답 객체],  // 기본 값으로 10개이며, 해당 페이지의 게시글 개수가 10개 미만이면, 해당하는 개수만큼 들어있어요.&#10;  &quot;totalPageCount&quot;: 3,  // 총 페이지 개수 &#10;  &quot;totalPostCount&quot;: 23  // 총 게시글 개수&#10;}&#10;&#10;- pageNo의 기본값은 0이에요. 만약 최신 게시글 10개만 불러오려면, /community 경로로 요청하면 돼요. 즉, 이 경우에는 물음표 뒤 생략이 가능해요.&#10;&#10;## 예제&#10;&#10;총 23개의 게시글이 존재하면, 총 3개의 페이지로 구분할 수 있어요.&#10;&#10;- 1번째부터 10번째 게시글&#10;- 11번째부터 20번째 게시글&#10;- 21번째부터 23번째 게시글&#10;&#10;따라서, 만약 11번째부터 20번째 게시글을 불러오고 싶으면, api 경로의 pageNo에 1를 넣어줘요. (/community?page=1)">
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/advice/exception/DuplicatedPostReportException.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/controller/ReportController.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/domain/PostReport.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/dto/ReportRequest.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/repository/CommentReportRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/repository/PostReportRepository.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/service/ReportService.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/report/controller/ReportControllerTest.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/report/service/ReportServiceTest.java" afterDir="false" />
+    <list default="true" id="5b42d689-d7d0-4ba2-a267-4384bfcc2fe3" name="Changes" comment="[HC-157] 게시글 신고 기능 구현&#10;&#10;게시글을 신고하기 위해 ReportRequest RequestBody를 담아 `/posts/{id}/report`로 Post 요청을 해야해요.&#10;&#10;요청이 성공하면, 상태값이 201인 응답을 반환해요.&#10;&#10;#### 동일한 게시글 다수 신고 불가&#10;&#10;동일한 게시글을 신고하면 에러를 반환해요.&#10;&#10;#### 게시글 응답 객체&#10;&#10;만약 신고 개수가 5개가 넘어가면, 해당 게시글은 신고 처리가 되어 게시글의 제목이랑 내용은 null로 전달해요.">
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/advice/exception/DuplicatedCommentReportException.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/domain/CommentReport.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/docs/asciidoc/index.adoc" beforeDir="false" afterPath="$PROJECT_DIR$/src/docs/asciidoc/index.adoc" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/advice/exception/ReplyDepthException.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/advice/exception/ReplyDepthException.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/domain/Post.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/domain/Post.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/dto/PostResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/dto/PostResponse.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/util/ControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/util/ControllerTest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/util/ResponseFixture.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/util/ResponseFixture.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/domain/Comment.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/domain/Comment.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/dto/CommentResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/dto/CommentResponse.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/dto/ReplyResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/dto/ReplyResponse.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/repository/CommentRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/comment/repository/CommentRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/controller/ReportController.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/controller/ReportController.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/repository/CommentReportRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/repository/CommentReportRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/service/ReportService.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/org/wooriverygood/api/report/service/ReportService.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/report/controller/ReportControllerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/report/controller/ReportControllerTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/report/service/ReportServiceTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/org/wooriverygood/api/report/service/ReportServiceTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -135,8 +132,11 @@
     "Gradle.PostServiceTest.likePost_down.executor": "Run",
     "Gradle.PostServiceTest.likePost_up.executor": "Debug",
     "Gradle.PostServiceTest.updatePost.executor": "Run",
+    "Gradle.ReportControllerTest.reportComment.executor": "Run",
     "Gradle.ReportControllerTest.reportPost (1).executor": "Run",
     "Gradle.ReportControllerTest.reportPost.executor": "Run",
+    "Gradle.ReportServiceTest.reportComment.executor": "Run",
+    "Gradle.ReportServiceTest.reportComment_exception_duplicated.executor": "Run",
     "Gradle.ReportServiceTest.reportPost.executor": "Run",
     "Gradle.ReportServiceTest.reportPost_exception_duplicated.executor": "Run",
     "Gradle.ReportServiceTest.reportPost_exception_invalidId.executor": "Run",
@@ -179,11 +179,11 @@
 }]]></component>
   <component name="RecentsManager">
     <key name="CreateClassDialog.RecentsKey">
+      <recent name="org.wooriverygood.api.advice.exception" />
+      <recent name="org.wooriverygood.api.report.domain" />
       <recent name="report.controller" />
       <recent name="org.wooriverygood.api.comment.dto" />
-      <recent name="org.wooriverygood.api.advice.exception" />
       <recent name="org.wooriverygood.api.exception" />
-      <recent name="org.wooriverygood.api.post.dto" />
     </key>
     <key name="CreateTestDialog.Recents.Supers">
       <recent name="" />
@@ -194,8 +194,8 @@
       <recent name="org.wooriverygood.api.post.controller" />
     </key>
   </component>
-  <component name="RunManager" selected="Gradle.ReportServiceTest.reportPost_exception_duplicated">
-    <configuration name="ReportControllerTest.reportPost (1)" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+  <component name="RunManager" selected="Gradle.ReportServiceTest.reportComment_exception_duplicated">
+    <configuration name="ReportControllerTest.reportComment" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -208,7 +208,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.report.controller.ReportControllerTest.reportPost&quot;" />
+            <option value="&quot;org.wooriverygood.api.report.controller.ReportControllerTest.reportComment&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -219,7 +219,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="ReportControllerTest.reportPost" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="ReportServiceTest.reportComment" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -232,7 +232,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;report.controller.ReportControllerTest.reportPost&quot;" />
+            <option value="&quot;org.wooriverygood.api.report.service.ReportServiceTest.reportComment&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -243,7 +243,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="ReportServiceTest.reportPost" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="ReportServiceTest.reportComment_exception_duplicated" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -256,7 +256,7 @@
           <list>
             <option value=":test" />
             <option value="--tests" />
-            <option value="&quot;org.wooriverygood.api.report.service.ReportServiceTest.reportPost&quot;" />
+            <option value="&quot;org.wooriverygood.api.report.service.ReportServiceTest.reportComment_exception_duplicated&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -317,11 +317,11 @@
     </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Gradle.ReportServiceTest.reportComment_exception_duplicated" />
+        <item itemvalue="Gradle.ReportServiceTest.reportComment" />
+        <item itemvalue="Gradle.ReportControllerTest.reportComment" />
         <item itemvalue="Gradle.ReportServiceTest.reportPost_exception_duplicated" />
         <item itemvalue="Gradle.ReportServiceTest.reportPost_exception_invalidId" />
-        <item itemvalue="Gradle.ReportServiceTest.reportPost" />
-        <item itemvalue="Gradle.ReportControllerTest.reportPost (1)" />
-        <item itemvalue="Gradle.ReportControllerTest.reportPost" />
       </list>
     </recent_temporary>
   </component>
@@ -595,7 +595,15 @@
       <option name="project" value="LOCAL" />
       <updated>1706186960797</updated>
     </task>
-    <option name="localTasksCounter" value="32" />
+    <task id="LOCAL-00032" summary="[HC-157] 게시글 신고 기능 구현&#10;&#10;게시글을 신고하기 위해 ReportRequest RequestBody를 담아 `/posts/{id}/report`로 Post 요청을 해야해요.&#10;&#10;요청이 성공하면, 상태값이 201인 응답을 반환해요.&#10;&#10;#### 동일한 게시글 다수 신고 불가&#10;&#10;동일한 게시글을 신고하면 에러를 반환해요.&#10;&#10;#### 게시글 응답 객체&#10;&#10;만약 신고 개수가 5개가 넘어가면, 해당 게시글은 신고 처리가 되어 게시글의 제목이랑 내용은 null로 전달해요.">
+      <option name="closed" value="true" />
+      <created>1706705822386</created>
+      <option name="number" value="00032" />
+      <option name="presentableId" value="LOCAL-00032" />
+      <option name="project" value="LOCAL" />
+      <updated>1706705822386</updated>
+    </task>
+    <option name="localTasksCounter" value="33" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -613,7 +621,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="[HC-68] 댓글 패키지 생성" />
     <MESSAGE value="[HC-68] 댓글 조회 기능 구현" />
     <MESSAGE value="[HC-68] 게시글 조회 응답 객체에 댓글 개수 추가" />
     <MESSAGE value="[HC-68] 게시글 및 댓글에 작성자 필드 추가" />
@@ -638,7 +645,8 @@
     <MESSAGE value="[HC-137] 게시글 수정 여부 반환 &#10;&#10;게시글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요." />
     <MESSAGE value="[HC-137] 댓글 및 답글 수정 여부 반환 &#10;&#10;댓글 및 답글 조회 응답 객체에 수정 여부(updated)도 같이 반환해요.&#10;&#10;만약 수정한 적이 있다면 updated의 값은 true에요." />
     <MESSAGE value="[HC-140] 게시글 페이지네이션 기능 구현 &#10;&#10;## api에 요청 시, 응답 객체 변경 (프론트에서 반영해줘야 함!!!)&#10;&#10;/community?page={pageNo} 에 요청 시, 다음과 같은 응답 객체 반환해요.&#10;&#10;{&#10;  &quot;posts&quot;: [기존 게시글 응답 객체],  // 기본 값으로 10개이며, 해당 페이지의 게시글 개수가 10개 미만이면, 해당하는 개수만큼 들어있어요.&#10;  &quot;totalPageCount&quot;: 3,  // 총 페이지 개수 &#10;  &quot;totalPostCount&quot;: 23  // 총 게시글 개수&#10;}&#10;&#10;- pageNo의 기본값은 0이에요. 만약 최신 게시글 10개만 불러오려면, /community 경로로 요청하면 돼요. 즉, 이 경우에는 물음표 뒤 생략이 가능해요.&#10;&#10;## 예제&#10;&#10;총 23개의 게시글이 존재하면, 총 3개의 페이지로 구분할 수 있어요.&#10;&#10;- 1번째부터 10번째 게시글&#10;- 11번째부터 20번째 게시글&#10;- 21번째부터 23번째 게시글&#10;&#10;따라서, 만약 11번째부터 20번째 게시글을 불러오고 싶으면, api 경로의 pageNo에 1를 넣어줘요. (/community?page=1)" />
-    <option name="LAST_COMMIT_MESSAGE" value="[HC-140] 게시글 페이지네이션 기능 구현 &#10;&#10;## api에 요청 시, 응답 객체 변경 (프론트에서 반영해줘야 함!!!)&#10;&#10;/community?page={pageNo} 에 요청 시, 다음과 같은 응답 객체 반환해요.&#10;&#10;{&#10;  &quot;posts&quot;: [기존 게시글 응답 객체],  // 기본 값으로 10개이며, 해당 페이지의 게시글 개수가 10개 미만이면, 해당하는 개수만큼 들어있어요.&#10;  &quot;totalPageCount&quot;: 3,  // 총 페이지 개수 &#10;  &quot;totalPostCount&quot;: 23  // 총 게시글 개수&#10;}&#10;&#10;- pageNo의 기본값은 0이에요. 만약 최신 게시글 10개만 불러오려면, /community 경로로 요청하면 돼요. 즉, 이 경우에는 물음표 뒤 생략이 가능해요.&#10;&#10;## 예제&#10;&#10;총 23개의 게시글이 존재하면, 총 3개의 페이지로 구분할 수 있어요.&#10;&#10;- 1번째부터 10번째 게시글&#10;- 11번째부터 20번째 게시글&#10;- 21번째부터 23번째 게시글&#10;&#10;따라서, 만약 11번째부터 20번째 게시글을 불러오고 싶으면, api 경로의 pageNo에 1를 넣어줘요. (/community?page=1)" />
+    <MESSAGE value="[HC-157] 게시글 신고 기능 구현&#10;&#10;게시글을 신고하기 위해 ReportRequest RequestBody를 담아 `/posts/{id}/report`로 Post 요청을 해야해요.&#10;&#10;요청이 성공하면, 상태값이 201인 응답을 반환해요.&#10;&#10;#### 동일한 게시글 다수 신고 불가&#10;&#10;동일한 게시글을 신고하면 에러를 반환해요.&#10;&#10;#### 게시글 응답 객체&#10;&#10;만약 신고 개수가 5개가 넘어가면, 해당 게시글은 신고 처리가 되어 게시글의 제목이랑 내용은 null로 전달해요." />
+    <option name="LAST_COMMIT_MESSAGE" value="[HC-157] 게시글 신고 기능 구현&#10;&#10;게시글을 신고하기 위해 ReportRequest RequestBody를 담아 `/posts/{id}/report`로 Post 요청을 해야해요.&#10;&#10;요청이 성공하면, 상태값이 201인 응답을 반환해요.&#10;&#10;#### 동일한 게시글 다수 신고 불가&#10;&#10;동일한 게시글을 신고하면 에러를 반환해요.&#10;&#10;#### 게시글 응답 객체&#10;&#10;만약 신고 개수가 5개가 넘어가면, 해당 게시글은 신고 처리가 되어 게시글의 제목이랑 내용은 null로 전달해요." />
   </component>
   <component name="XDebuggerManager">
     <breakpoint-manager>

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -147,3 +147,7 @@ operation::reply/create/fail/depth[snippets='http-request,http-response']
 === 특정 게시글 신고하기 (POST /posts/{id}/report)
 ==== 성공
 operation::posts/report/success[snippets='http-request,http-response']
+
+=== 특정 댓글 신고하기 (POST /comments/{id}/report)
+==== 성공
+operation::comments/report/success[snippets='http-request,http-response']

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -141,3 +141,9 @@ operation::reply/create/success[snippets='http-request,http-response']
 ==== 실패
 ===== 대댓글에 작성하는 경우
 operation::reply/create/fail/depth[snippets='http-request,http-response']
+
+== 신고 관리
+
+=== 특정 게시글 신고하기 (POST /posts/{id}/report)
+==== 성공
+operation::posts/report/success[snippets='http-request,http-response']

--- a/src/main/java/org/wooriverygood/api/advice/exception/DuplicatedCommentReportException.java
+++ b/src/main/java/org/wooriverygood/api/advice/exception/DuplicatedCommentReportException.java
@@ -1,0 +1,12 @@
+package org.wooriverygood.api.advice.exception;
+
+import org.wooriverygood.api.advice.exception.general.BadRequestException;
+
+public class DuplicatedCommentReportException extends BadRequestException {
+
+    private static final String MESSAGE = "이미 신고한 댓글이에요.";
+
+    public DuplicatedCommentReportException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/org/wooriverygood/api/advice/exception/DuplicatedPostReportException.java
+++ b/src/main/java/org/wooriverygood/api/advice/exception/DuplicatedPostReportException.java
@@ -1,0 +1,12 @@
+package org.wooriverygood.api.advice.exception;
+
+import org.wooriverygood.api.advice.exception.general.BadRequestException;
+
+public class DuplicatedPostReportException extends BadRequestException {
+
+    private static final String MESSAGE = "이미 신고한 게시글이에요.";
+
+    public DuplicatedPostReportException() {
+        super(MESSAGE);
+    }
+}

--- a/src/main/java/org/wooriverygood/api/advice/exception/ReplyDepthException.java
+++ b/src/main/java/org/wooriverygood/api/advice/exception/ReplyDepthException.java
@@ -4,7 +4,7 @@ import org.wooriverygood.api.advice.exception.general.BadRequestException;
 
 public class ReplyDepthException extends BadRequestException {
 
-    private static final String MESSAGE = "대댓글에 답글을 달 수 없습니다.";
+    private static final String MESSAGE = "답글에 답글을 달 수 없습니다.";
 
     public ReplyDepthException() {
         super(MESSAGE);

--- a/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
+++ b/src/main/java/org/wooriverygood/api/comment/domain/Comment.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.wooriverygood.api.advice.exception.AuthorizationException;
 import org.wooriverygood.api.post.domain.Post;
+import org.wooriverygood.api.report.domain.CommentReport;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -51,6 +52,13 @@ public class Comment {
     @ColumnDefault("0")
     private int likeCount;
 
+    @OneToMany(mappedBy = "comment")
+    private List<CommentReport> reports;
+
+    @Column(name = "report_count")
+    @ColumnDefault("0")
+    private int reportCount;
+
     @Column(name = "comment_time")
     @CreatedDate
     private LocalDateTime createdAt;
@@ -63,13 +71,14 @@ public class Comment {
     private boolean updated;
 
     @Builder
-    public Comment(Long id, String content, String author, Post post, Comment parent, List<CommentLike> commentLikes, boolean softRemoved, boolean updated) {
+    public Comment(Long id, String content, String author, Post post, Comment parent, List<CommentLike> commentLikes, List<CommentReport> reports, boolean softRemoved, boolean updated) {
         this.id = id;
         this.content = content;
         this.author = author;
         this.post = post;
         this.parent = parent;
         this.commentLikes = commentLikes;
+        this.reports = reports;
         this.softRemoved = softRemoved;
         this.updated = updated;
     }
@@ -81,6 +90,17 @@ public class Comment {
     public void deleteCommentLike(CommentLike commentLike) {
         commentLikes.remove(commentLike);
         commentLike.delete();
+    }
+
+    public void addReport(CommentReport report) {
+        reports.add(report);
+    }
+
+    public boolean hasReportByUser(String username) {
+        for (CommentReport report: reports)
+            if (report.isOwner(username))
+                return true;
+        return false;
     }
 
     public void validateAuthor(String author) {

--- a/src/main/java/org/wooriverygood/api/comment/dto/CommentResponse.java
+++ b/src/main/java/org/wooriverygood/api/comment/dto/CommentResponse.java
@@ -28,9 +28,11 @@ public class CommentResponse {
 
     private final boolean updated;
 
+    private final boolean reported;
+
 
     @Builder
-    public CommentResponse(Long comment_id, String comment_content, String comment_author, Long post_id, int comment_likes, LocalDateTime comment_time, boolean liked, List<ReplyResponse> replies, boolean updated) {
+    public CommentResponse(Long comment_id, String comment_content, String comment_author, Long post_id, int comment_likes, LocalDateTime comment_time, boolean liked, List<ReplyResponse> replies, boolean updated, boolean reported) {
         this.comment_id = comment_id;
         this.comment_content = comment_content;
         this.comment_author = comment_author;
@@ -40,13 +42,15 @@ public class CommentResponse {
         this.liked = liked;
         this.replies = replies;
         this.updated = updated;
+        this.reported = reported;
     }
 
 
     public static CommentResponse from(Comment comment, List<ReplyResponse> replies, boolean liked) {
+        boolean reported = comment.getReportCount() >= 5;
         return CommentResponse.builder()
                 .comment_id(comment.getId())
-                .comment_content(comment.getContent())
+                .comment_content(reported ? null : comment.getContent())
                 .comment_author(comment.getAuthor())
                 .post_id(comment.getPost().getId())
                 .comment_likes(comment.getLikeCount())
@@ -54,10 +58,12 @@ public class CommentResponse {
                 .liked(liked)
                 .replies(replies)
                 .updated(comment.isUpdated())
+                .reported(reported)
                 .build();
     }
 
     public static CommentResponse softRemovedFrom(Comment comment, List<ReplyResponse> replies) {
+        boolean reported = comment.getReportCount() >= 5;
         return CommentResponse.builder()
                 .comment_id(comment.getId())
                 .comment_content(null)
@@ -67,6 +73,7 @@ public class CommentResponse {
                 .comment_time(comment.getCreatedAt())
                 .replies(replies)
                 .updated(comment.isUpdated())
+                .reported(reported)
                 .build();
     }
 }

--- a/src/main/java/org/wooriverygood/api/comment/dto/ReplyResponse.java
+++ b/src/main/java/org/wooriverygood/api/comment/dto/ReplyResponse.java
@@ -22,10 +22,12 @@ public class ReplyResponse {
 
     private final boolean updated;
 
+    private final boolean reported;
+
 
     @Builder
 
-    public ReplyResponse(Long reply_id, String reply_content, String reply_author, int reply_likes, LocalDateTime reply_time, boolean liked, boolean updated) {
+    public ReplyResponse(Long reply_id, String reply_content, String reply_author, int reply_likes, LocalDateTime reply_time, boolean liked, boolean updated, boolean reported) {
         this.reply_id = reply_id;
         this.reply_content = reply_content;
         this.reply_author = reply_author;
@@ -33,17 +35,20 @@ public class ReplyResponse {
         this.reply_time = reply_time;
         this.liked = liked;
         this.updated = updated;
+        this.reported = reported;
     }
 
     public static ReplyResponse from(Comment reply, boolean liked) {
+        boolean reported = reply.getReportCount() >= 5;
         return ReplyResponse.builder()
                 .reply_id(reply.getId())
-                .reply_content(reply.getContent())
+                .reply_content(reported ? null : reply.getContent())
                 .reply_author(reply.getAuthor())
                 .reply_likes(reply.getLikeCount())
                 .reply_time(reply.getCreatedAt())
                 .liked(liked)
                 .updated(reply.isUpdated())
+                .reported(reported)
                 .build();
     }
 

--- a/src/main/java/org/wooriverygood/api/comment/repository/CommentRepository.java
+++ b/src/main/java/org/wooriverygood/api/comment/repository/CommentRepository.java
@@ -25,4 +25,8 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query(value = "UPDATE comments SET like_count = like_count - 1 WHERE comment_id = :commentId", nativeQuery = true)
     void decreaseLikeCount(Long commentId);
 
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE comments SET report_count = report_count + 1 WHERE comment_id = :commentId", nativeQuery = true)
+    void increaseReportCount(Long commentId);
 }

--- a/src/main/java/org/wooriverygood/api/post/domain/Post.java
+++ b/src/main/java/org/wooriverygood/api/post/domain/Post.java
@@ -9,6 +9,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import org.wooriverygood.api.advice.exception.AuthorizationException;
 import org.wooriverygood.api.comment.domain.Comment;
+import org.wooriverygood.api.report.domain.PostReport;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -48,6 +49,13 @@ public class Post {
     @ColumnDefault("0")
     private int likeCount;
 
+    @OneToMany(mappedBy = "post")
+    private List<PostReport> reports;
+
+    @Column(name = "report_count")
+    @ColumnDefault("0")
+    private int reportCount;
+
     @ColumnDefault("false")
     private boolean updated;
 
@@ -57,7 +65,7 @@ public class Post {
 
 
     @Builder
-    public Post(Long id, PostCategory category, String title, String content, String author, List<Comment> comments, List<PostLike> postLikes, boolean updated) {
+    public Post(Long id, PostCategory category, String title, String content, String author, List<Comment> comments, List<PostLike> postLikes, List<PostReport> reports, boolean updated) {
         this.id = id;
         this.category = category;
         this.title = title;
@@ -65,6 +73,7 @@ public class Post {
         this.author = author;
         this.comments = comments;
         this.postLikes = postLikes;
+        this.reports = reports;
         this.updated = updated;
     }
 
@@ -86,6 +95,10 @@ public class Post {
         updated = true;
     }
 
+    public void addReport(PostReport report) {
+        reports.add(report);
+    }
+
     public void updateContent(String content) {
         this.content = content;
         updated = true;
@@ -95,6 +108,13 @@ public class Post {
         if (comments == null)
             return 0;
         return comments.size();
+    }
+
+    public boolean hasReportByUser(String username) {
+        for (PostReport report: reports)
+            if (report.isOwner(username))
+                return true;
+        return false;
     }
 
 }

--- a/src/main/java/org/wooriverygood/api/post/dto/PostResponse.java
+++ b/src/main/java/org/wooriverygood/api/post/dto/PostResponse.java
@@ -29,9 +29,11 @@ public class PostResponse {
 
     private final boolean updated;
 
+    private final boolean reported;
+
 
     @Builder
-    public PostResponse(Long post_id, String post_title, String post_content, String post_category, String post_author, int post_comments, int post_likes, LocalDateTime post_time, boolean liked, boolean updated) {
+    public PostResponse(Long post_id, String post_title, String post_content, String post_category, String post_author, int post_comments, int post_likes, LocalDateTime post_time, boolean liked, boolean updated, boolean reported) {
         this.post_id = post_id;
         this.post_title = post_title;
         this.post_content = post_content;
@@ -42,13 +44,15 @@ public class PostResponse {
         this.post_time = post_time;
         this.liked = liked;
         this.updated = updated;
+        this.reported = reported;
     }
 
     public static PostResponse from(Post post, boolean liked) {
+        boolean reported = post.getReportCount() >= 5;
         return PostResponse.builder()
                 .post_id(post.getId())
-                .post_title(post.getTitle())
-                .post_content(post.getContent())
+                .post_title(reported ? null : post.getTitle())
+                .post_content(reported ? null : post.getContent())
                 .post_category(post.getCategory().getValue())
                 .post_author(post.getAuthor())
                 .post_comments(post.getCommentCount())
@@ -56,6 +60,7 @@ public class PostResponse {
                 .post_time(post.getCreatedAt())
                 .liked(liked)
                 .updated(post.isUpdated())
+                .reported(reported)
                 .build();
     }
 

--- a/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java
+++ b/src/main/java/org/wooriverygood/api/post/repository/PostRepository.java
@@ -27,4 +27,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @Modifying(clearAutomatically = true)
     @Query(value = "UPDATE posts SET like_count = like_count - 1 WHERE post_id = :postId", nativeQuery = true)
     void decreaseLikeCount(Long postId);
+
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query(value = "UPDATE posts SET report_count = report_count - 1 WHERE post_id = :postId", nativeQuery = true)
+    void increaseReportCount(Long postId);
 }

--- a/src/main/java/org/wooriverygood/api/report/controller/ReportController.java
+++ b/src/main/java/org/wooriverygood/api/report/controller/ReportController.java
@@ -30,4 +30,12 @@ public class ReportController {
         reportService.reportPost(postId, request, authInfo);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
+    @PostMapping("/comments/{id}/report")
+    public ResponseEntity<Void> reportComment(@PathVariable("id") Long commentId,
+                                              @Valid @RequestBody ReportRequest request,
+                                              @Login AuthInfo authInfo) {
+        reportService.reportComment(commentId, request, authInfo);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 }

--- a/src/main/java/org/wooriverygood/api/report/controller/ReportController.java
+++ b/src/main/java/org/wooriverygood/api/report/controller/ReportController.java
@@ -1,0 +1,33 @@
+package org.wooriverygood.api.report.controller;
+
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import org.wooriverygood.api.report.dto.ReportRequest;
+import org.wooriverygood.api.report.service.ReportService;
+import org.wooriverygood.api.support.AuthInfo;
+import org.wooriverygood.api.support.Login;
+
+@RestController
+public class ReportController {
+
+    private final ReportService reportService;
+
+
+    public ReportController(ReportService reportService) {
+        this.reportService = reportService;
+    }
+
+
+    @PostMapping("/posts/{id}/report")
+    public ResponseEntity<Void> reportPost(@PathVariable("id") Long postId,
+                                           @Valid @RequestBody ReportRequest request,
+                                           @Login AuthInfo authInfo) {
+        reportService.reportPost(postId, request, authInfo);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/org/wooriverygood/api/report/domain/CommentReport.java
+++ b/src/main/java/org/wooriverygood/api/report/domain/CommentReport.java
@@ -1,0 +1,39 @@
+package org.wooriverygood.api.report.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.wooriverygood.api.comment.domain.Comment;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class CommentReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", referencedColumnName = "comment_id")
+    private Comment comment;
+
+    @Column
+    private String username;
+
+    private String message;
+
+
+    @Builder
+    public CommentReport(Long id, Comment comment, String username, String message) {
+        this.id = id;
+        this.comment = comment;
+        this.username = username;
+        this.message = message;
+    }
+
+    public boolean isOwner(String username) {
+        return this.username.equals(username);
+    }
+}

--- a/src/main/java/org/wooriverygood/api/report/domain/PostReport.java
+++ b/src/main/java/org/wooriverygood/api/report/domain/PostReport.java
@@ -1,0 +1,40 @@
+package org.wooriverygood.api.report.domain;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.wooriverygood.api.post.domain.Post;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class PostReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", referencedColumnName = "post_id")
+    private Post post;
+
+    @Column
+    private String username;
+
+    private String message;
+
+
+    @Builder
+    public PostReport(Long id, Post post, String username, String message) {
+        this.id = id;
+        this.post = post;
+        this.username = username;
+        this.message = message;
+    }
+
+    public boolean isOwner(String username) {
+        return this.username.equals(username);
+    }
+
+}

--- a/src/main/java/org/wooriverygood/api/report/dto/ReportRequest.java
+++ b/src/main/java/org/wooriverygood/api/report/dto/ReportRequest.java
@@ -1,0 +1,19 @@
+package org.wooriverygood.api.report.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ReportRequest {
+
+    @NotBlank(message = "신고내용은 1자 이상 255자 이하여야 합니다.")
+    private String message;
+
+    @Builder
+    public ReportRequest(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/org/wooriverygood/api/report/repository/CommentReportRepository.java
+++ b/src/main/java/org/wooriverygood/api/report/repository/CommentReportRepository.java
@@ -1,0 +1,4 @@
+package org.wooriverygood.api.report.repository;
+
+public interface CommentReportRepository {
+}

--- a/src/main/java/org/wooriverygood/api/report/repository/CommentReportRepository.java
+++ b/src/main/java/org/wooriverygood/api/report/repository/CommentReportRepository.java
@@ -1,4 +1,7 @@
 package org.wooriverygood.api.report.repository;
 
-public interface CommentReportRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.wooriverygood.api.report.domain.CommentReport;
+
+public interface CommentReportRepository extends JpaRepository<CommentReport, Long> {
 }

--- a/src/main/java/org/wooriverygood/api/report/repository/PostReportRepository.java
+++ b/src/main/java/org/wooriverygood/api/report/repository/PostReportRepository.java
@@ -1,0 +1,7 @@
+package org.wooriverygood.api.report.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.wooriverygood.api.report.domain.PostReport;
+
+public interface PostReportRepository extends JpaRepository<PostReport, Long> {
+}

--- a/src/main/java/org/wooriverygood/api/report/service/ReportService.java
+++ b/src/main/java/org/wooriverygood/api/report/service/ReportService.java
@@ -2,12 +2,18 @@ package org.wooriverygood.api.report.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.wooriverygood.api.advice.exception.CommentNotFoundException;
+import org.wooriverygood.api.advice.exception.DuplicatedCommentReportException;
 import org.wooriverygood.api.advice.exception.DuplicatedPostReportException;
 import org.wooriverygood.api.advice.exception.PostNotFoundException;
+import org.wooriverygood.api.comment.domain.Comment;
+import org.wooriverygood.api.comment.repository.CommentRepository;
 import org.wooriverygood.api.post.domain.Post;
 import org.wooriverygood.api.post.repository.PostRepository;
+import org.wooriverygood.api.report.domain.CommentReport;
 import org.wooriverygood.api.report.domain.PostReport;
 import org.wooriverygood.api.report.dto.ReportRequest;
+import org.wooriverygood.api.report.repository.CommentReportRepository;
 import org.wooriverygood.api.report.repository.PostReportRepository;
 import org.wooriverygood.api.support.AuthInfo;
 
@@ -15,12 +21,18 @@ import org.wooriverygood.api.support.AuthInfo;
 @Transactional
 public class ReportService {
 
+    private final CommentRepository commentRepository;
+
+    private final CommentReportRepository commentReportRepository;
+
     private final PostRepository postRepository;
 
     private final PostReportRepository postReportRepository;
 
 
-    public ReportService(PostRepository postRepository, PostReportRepository postReportRepository) {
+    public ReportService(CommentRepository commentRepository, CommentReportRepository commentReportRepository, PostRepository postRepository, PostReportRepository postReportRepository) {
+        this.commentRepository = commentRepository;
+        this.commentReportRepository = commentReportRepository;
         this.postRepository = postRepository;
         this.postReportRepository = postReportRepository;
     }
@@ -47,4 +59,25 @@ public class ReportService {
             throw new DuplicatedPostReportException();
     }
 
+    public void reportComment(Long commentId, ReportRequest request, AuthInfo authInfo) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(CommentNotFoundException::new);
+
+        CommentReport report = CommentReport.builder()
+                .comment(comment)
+                .message(request.getMessage())
+                .username(authInfo.getUsername())
+                .build();
+
+        checkAlreadyReport(comment, authInfo);
+        comment.addReport(report);
+        commentRepository.increaseReportCount(commentId);
+
+        commentReportRepository.save(report);
+    }
+
+    private void checkAlreadyReport(Comment comment, AuthInfo authInfo) {
+        if (comment.hasReportByUser(authInfo.getUsername()))
+            throw new DuplicatedCommentReportException();
+    }
 }

--- a/src/main/java/org/wooriverygood/api/report/service/ReportService.java
+++ b/src/main/java/org/wooriverygood/api/report/service/ReportService.java
@@ -1,0 +1,50 @@
+package org.wooriverygood.api.report.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.wooriverygood.api.advice.exception.DuplicatedPostReportException;
+import org.wooriverygood.api.advice.exception.PostNotFoundException;
+import org.wooriverygood.api.post.domain.Post;
+import org.wooriverygood.api.post.repository.PostRepository;
+import org.wooriverygood.api.report.domain.PostReport;
+import org.wooriverygood.api.report.dto.ReportRequest;
+import org.wooriverygood.api.report.repository.PostReportRepository;
+import org.wooriverygood.api.support.AuthInfo;
+
+@Service
+@Transactional
+public class ReportService {
+
+    private final PostRepository postRepository;
+
+    private final PostReportRepository postReportRepository;
+
+
+    public ReportService(PostRepository postRepository, PostReportRepository postReportRepository) {
+        this.postRepository = postRepository;
+        this.postReportRepository = postReportRepository;
+    }
+
+    public void reportPost(Long postId, ReportRequest request, AuthInfo authInfo) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(PostNotFoundException::new);
+
+        PostReport report = PostReport.builder()
+                .post(post)
+                .message(request.getMessage())
+                .username(authInfo.getUsername())
+                .build();
+
+        checkAlreadyReport(post, authInfo);
+        post.addReport(report);
+        postRepository.increaseReportCount(postId);
+
+        postReportRepository.save(report);
+    }
+
+    private void checkAlreadyReport(Post post, AuthInfo authInfo) {
+        if (post.hasReportByUser(authInfo.getUsername()))
+            throw new DuplicatedPostReportException();
+    }
+
+}

--- a/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java
+++ b/src/test/java/org/wooriverygood/api/comment/controller/CommentControllerTest.java
@@ -51,6 +51,7 @@ class CommentControllerTest extends ControllerTest {
                     .liked(i % 3 == 0)
                     .replies(new ArrayList<>())
                     .updated(i % 2 == 0)
+                    .reported(false)
                     .build());
         }
         for (int i = 12; i <= 15; i++) {
@@ -63,6 +64,7 @@ class CommentControllerTest extends ControllerTest {
                             .reply_time(LocalDateTime.now())
                             .liked(false)
                             .updated(i % 2 == 0)
+                            .reported(false)
                             .build());
         }
     }

--- a/src/test/java/org/wooriverygood/api/report/controller/ReportControllerTest.java
+++ b/src/test/java/org/wooriverygood/api/report/controller/ReportControllerTest.java
@@ -34,5 +34,26 @@ public class ReportControllerTest extends ControllerTest {
                 .apply(document("posts/report/success"))
                 .statusCode(HttpStatus.CREATED.value());
     }
+
+    @Test
+    @DisplayName("특정 댓글을 신고하면 201을 반환한다.")
+    void reportComment() {
+        ReportRequest request = ReportRequest.builder()
+                .message("신고 내용")
+                .build();
+
+        doNothing().when(reportService)
+                .reportComment(any(Long.class), any(ReportRequest.class), any(AuthInfo.class));
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer aws-cognito-access-token")
+                .body(request)
+                .when().post("/comments/1/report")
+                .then().log().all()
+                .assertThat()
+                .apply(document("comments/report/success"))
+                .statusCode(HttpStatus.CREATED.value());
+    }
 }
 

--- a/src/test/java/org/wooriverygood/api/report/controller/ReportControllerTest.java
+++ b/src/test/java/org/wooriverygood/api/report/controller/ReportControllerTest.java
@@ -1,0 +1,38 @@
+package org.wooriverygood.api.report.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.wooriverygood.api.report.dto.ReportRequest;
+import org.wooriverygood.api.support.AuthInfo;
+import org.wooriverygood.api.util.ControllerTest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+
+public class ReportControllerTest extends ControllerTest {
+
+    @Test
+    @DisplayName("특정 게시글을 신고하면 201을 반환한다.")
+    void reportPost() {
+        ReportRequest request = ReportRequest.builder()
+                .message("신고 내용")
+                .build();
+
+        doNothing().when(reportService)
+                .reportPost(any(Long.class), any(ReportRequest.class), any(AuthInfo.class));
+
+        restDocs
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .header("Authorization", "Bearer aws-cognito-access-token")
+                .body(request)
+                .when().post("/posts/1/report")
+                .then().log().all()
+                .assertThat()
+                .apply(document("posts/report/success"))
+                .statusCode(HttpStatus.CREATED.value());
+    }
+}
+

--- a/src/test/java/org/wooriverygood/api/report/service/ReportServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/report/service/ReportServiceTest.java
@@ -7,12 +7,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.wooriverygood.api.advice.exception.CommentNotFoundException;
+import org.wooriverygood.api.advice.exception.DuplicatedCommentReportException;
 import org.wooriverygood.api.advice.exception.DuplicatedPostReportException;
 import org.wooriverygood.api.advice.exception.PostNotFoundException;
+import org.wooriverygood.api.comment.domain.Comment;
+import org.wooriverygood.api.comment.repository.CommentRepository;
 import org.wooriverygood.api.post.domain.Post;
 import org.wooriverygood.api.post.domain.PostCategory;
 import org.wooriverygood.api.post.repository.PostRepository;
 import org.wooriverygood.api.report.dto.ReportRequest;
+import org.wooriverygood.api.report.repository.CommentReportRepository;
 import org.wooriverygood.api.report.repository.PostReportRepository;
 import org.wooriverygood.api.support.AuthInfo;
 
@@ -31,6 +36,12 @@ class ReportServiceTest {
     private ReportService reportService;
 
     @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private CommentReportRepository commentReportRepository;
+
+    @Mock
     private PostRepository postRepository;
 
     @Mock
@@ -39,6 +50,8 @@ class ReportServiceTest {
     private AuthInfo testAuthInfo;
 
     private Post testPost;
+
+    private Comment testComment;
 
 
     @BeforeEach
@@ -56,6 +69,14 @@ class ReportServiceTest {
                 .author(testAuthInfo.getUsername())
                 .comments(new ArrayList<>())
                 .postLikes(new ArrayList<>())
+                .reports(new ArrayList<>())
+                .build();
+
+        testComment = Comment.builder()
+                .id(1L)
+                .content("comment content")
+                .author(testAuthInfo.getUsername())
+                .commentLikes(new ArrayList<>())
                 .reports(new ArrayList<>())
                 .build();
     }
@@ -102,6 +123,50 @@ class ReportServiceTest {
 
         assertThatThrownBy(() -> reportService.reportPost(1L, request, testAuthInfo))
                 .isInstanceOf(DuplicatedPostReportException.class);
+    }
+
+    @Test
+    @DisplayName("유효한 id를 통해 특정 댓글을 신고한다.")
+    void reportComment() {
+        ReportRequest request = ReportRequest.builder()
+                .message("report message")
+                .build();
+
+        when(commentRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(testComment));
+
+        reportService.reportComment(1L, request, testAuthInfo);
+
+        assertThat(testComment.getReports().size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("신고하려는 댓글의 id가 유효하지 않으면 예외를 발생한다.")
+    void reportComment_exception_invalidId() {
+        ReportRequest request = ReportRequest.builder()
+                .message("report message")
+                .build();
+
+        when(commentRepository.findById(any(Long.class)))
+                .thenThrow(new CommentNotFoundException());
+
+        assertThatThrownBy(() -> reportService.reportComment(1L, request, testAuthInfo))
+                .isInstanceOf(CommentNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("동일한 댓글을 한 번 이상 신고하면 예외를 발생한다.")
+    void reportComment_exception_duplicated() {
+        ReportRequest request = ReportRequest.builder()
+                .message("report message")
+                .build();
+
+        when(commentRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(testComment));
+        reportService.reportComment(1L, request, testAuthInfo);
+
+        assertThatThrownBy(() -> reportService.reportComment(1L, request, testAuthInfo))
+                .isInstanceOf(DuplicatedCommentReportException.class);
     }
 
 }

--- a/src/test/java/org/wooriverygood/api/report/service/ReportServiceTest.java
+++ b/src/test/java/org/wooriverygood/api/report/service/ReportServiceTest.java
@@ -1,0 +1,107 @@
+package org.wooriverygood.api.report.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.wooriverygood.api.advice.exception.DuplicatedPostReportException;
+import org.wooriverygood.api.advice.exception.PostNotFoundException;
+import org.wooriverygood.api.post.domain.Post;
+import org.wooriverygood.api.post.domain.PostCategory;
+import org.wooriverygood.api.post.repository.PostRepository;
+import org.wooriverygood.api.report.dto.ReportRequest;
+import org.wooriverygood.api.report.repository.PostReportRepository;
+import org.wooriverygood.api.support.AuthInfo;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @InjectMocks
+    private ReportService reportService;
+
+    @Mock
+    private PostRepository postRepository;
+
+    @Mock
+    private PostReportRepository postReportRepository;
+
+    private AuthInfo testAuthInfo;
+
+    private Post testPost;
+
+
+    @BeforeEach
+    void setUp() {
+        testAuthInfo = AuthInfo.builder()
+                .sub("22432-12312-3531")
+                .username("22432-12312-3531")
+                .build();
+
+        testPost = Post.builder()
+                .id(1L)
+                .category(PostCategory.OFFER)
+                .title("post title")
+                .content("post content")
+                .author(testAuthInfo.getUsername())
+                .comments(new ArrayList<>())
+                .postLikes(new ArrayList<>())
+                .reports(new ArrayList<>())
+                .build();
+    }
+
+    @Test
+    @DisplayName("유효한 id를 통해 특정 게시글을 신고한다.")
+    void reportPost() {
+        ReportRequest request = ReportRequest.builder()
+                .message("report message")
+                .build();
+
+        when(postRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(testPost));
+
+        reportService.reportPost(1L, request, testAuthInfo);
+
+        assertThat(testPost.getReports().size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("신고하려는 게시글 id가 유효하지 않으면 예외를 발생한다.")
+    void reportPost_exception_invalidId() {
+        ReportRequest request = ReportRequest.builder()
+                .message("report message")
+                .build();
+
+        when(postRepository.findById(any(Long.class)))
+                .thenThrow(new PostNotFoundException());
+
+        assertThatThrownBy(() -> reportService.reportPost(1L, request, testAuthInfo))
+                .isInstanceOf(PostNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("동일한 게시글을 한 번 이상 신고하면 예외를 발생한다.")
+    void reportPost_exception_duplicated() {
+        ReportRequest request = ReportRequest.builder()
+                .message("report message")
+                .build();
+
+        when(postRepository.findById(any(Long.class)))
+                .thenReturn(Optional.ofNullable(testPost));
+        reportService.reportPost(1L, request, testAuthInfo);
+
+        assertThatThrownBy(() -> reportService.reportPost(1L, request, testAuthInfo))
+                .isInstanceOf(DuplicatedPostReportException.class);
+    }
+
+}

--- a/src/test/java/org/wooriverygood/api/util/ControllerTest.java
+++ b/src/test/java/org/wooriverygood/api/util/ControllerTest.java
@@ -13,6 +13,8 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.wooriverygood.api.comment.controller.CommentController;
 import org.wooriverygood.api.comment.service.CommentService;
+import org.wooriverygood.api.report.controller.ReportController;
+import org.wooriverygood.api.report.service.ReportService;
 import org.wooriverygood.api.course.controller.CourseController;
 import org.wooriverygood.api.course.service.CourseService;
 import org.wooriverygood.api.post.controller.PostController;
@@ -33,7 +35,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
         CommentController.class,
         PostController.class,
         CourseController.class,
-        ReviewController.class
+        ReviewController.class,
+        ReportController.class
 })
 @WithMockUser
 @ExtendWith(RestDocumentationExtension.class)
@@ -52,6 +55,9 @@ public class ControllerTest {
 
     @MockBean
     protected PostService postService;
+
+    @MockBean
+    protected ReportService reportService;
 
     @MockBean
     protected AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver;

--- a/src/test/java/org/wooriverygood/api/util/ResponseFixture.java
+++ b/src/test/java/org/wooriverygood/api/util/ResponseFixture.java
@@ -31,6 +31,31 @@ public class ResponseFixture {
                 .post_time(LocalDateTime.now())
                 .liked(id % 6 == 0)
                 .updated(id % 9 == 0)
+                .reported(false)
+                .build();
+    }
+
+    public static PostResponse reportedPostResponse(long id, AuthInfo authInfo) {
+        String category = "자유";
+        if (id % 3 == 0) category = "중고거래";
+        else if (id % 5 == 0) category = "구인";
+        else if (id % 7 == 0) category = "질문";
+        return reportedPostResponse(id, category, authInfo);
+    }
+
+    public static PostResponse reportedPostResponse(long id, String category, AuthInfo authInfo) {
+        return PostResponse.builder()
+                .post_id(id)
+                .post_title(null)
+                .post_category(category)
+                .post_content(null)
+                .post_author(authInfo.getUsername())
+                .post_comments((int) (Math.random() * 100))
+                .post_likes((int) (Math.random() * 100))
+                .post_time(LocalDateTime.now())
+                .liked(id % 6 == 0)
+                .updated(id % 9 == 0)
+                .reported(true)
                 .build();
     }
 
@@ -38,8 +63,10 @@ public class ResponseFixture {
         List<PostResponse> responses = new ArrayList<>();
         int bound = Math.min(totalCount - page * 10 + 1, 10);
         int start = page * 10 + 1;
-        for (int i = start; i < start + bound; i++)
-            responses.add(postResponse(i, authInfo));
+        for (int i = start; i < start + bound; i++) {
+            if (i % 5 == 0) responses.add(reportedPostResponse(i, authInfo));
+            else responses.add(postResponse(i, authInfo));
+        }
         return PostsResponse.builder()
                 .posts(responses)
                 .totalPostCount(totalCount)
@@ -51,8 +78,10 @@ public class ResponseFixture {
         List<PostResponse> responses = new ArrayList<>();
         int bound = Math.min(totalCount - page * 10 + 1, 10);
         int start = page * 10 + 1;
-        for (int i = start; i < start + bound; i++)
-            responses.add(postResponse(i, category, authInfo));
+        for (int i = start; i < start + bound; i++) {
+            if (i % 5 == 0) responses.add(reportedPostResponse(i, authInfo));
+            else responses.add(postResponse(i, authInfo));
+        }
         return PostsResponse.builder()
                 .posts(responses)
                 .totalPostCount(totalCount)


### PR DESCRIPTION
게시글 혹은 댓글(답글)을 신고하기 위해선 ReportRequest를 RequestBody에 담아 `/posts/{id}/report` 혹은 `/comments/{id}/report`로 Post 요청을 해야해요.

요청이 성공하면, 상태값이 201인 응답을 반환해요. ResponseBody는 없어요.

#### 동일한 게시글 및 댓글(답글) 다수 신고 불가

동일한 게시글 및 댓글(답글)을 신고하면 에러를 반환해요.

#### 게시글 및 댓글(답글) 응답 객체

만약 신고 개수가 5개가 넘어가면, 해당 게시글은 신고 처리가 되어 게시글의 제목이랑 내용은 null로 전달해요.

만약 댓글(답글)이라면 내용을 null로 전달해요.